### PR TITLE
44 Set language from the command line

### DIFF
--- a/src/main/java/fr/cnes/sonar/report/ReportCommandLine.java
+++ b/src/main/java/fr/cnes/sonar/report/ReportCommandLine.java
@@ -81,8 +81,7 @@ public final class ReportCommandLine {
 
             // Set the language of the report.
             // assumes the language is set with language_country
-            String[] locale = conf.getLanguage().split("_");
-            StringManager.changeLocale(locale[0], locale[1]);
+            StringManager.changeLocale(conf.getLanguage());
 
             // Display version information and exit.
             if(conf.isVersion()) {

--- a/src/main/java/fr/cnes/sonar/report/ReportCommandLine.java
+++ b/src/main/java/fr/cnes/sonar/report/ReportCommandLine.java
@@ -27,6 +27,7 @@ import fr.cnes.sonar.report.factory.ServerFactory;
 import fr.cnes.sonar.report.model.Report;
 import fr.cnes.sonar.report.model.SonarQubeServer;
 import fr.cnes.sonar.report.utils.ReportConfiguration;
+import fr.cnes.sonar.report.utils.StringManager;
 import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
 import org.apache.xmlbeans.XmlException;
 
@@ -77,6 +78,11 @@ public final class ReportCommandLine {
 
             // Parse command line arguments.
             final ReportConfiguration conf = ReportConfiguration.create(args);
+
+            // Set the language of the report.
+            // assumes the language is set with language_country
+            String[] locale = conf.getLanguage().split("_");
+            StringManager.changeLocale(locale[0], locale[1]);
 
             // Display version information and exit.
             if(conf.isVersion()) {

--- a/src/main/java/fr/cnes/sonar/report/utils/StringManager.java
+++ b/src/main/java/fr/cnes/sonar/report/utils/StringManager.java
@@ -102,6 +102,9 @@ public final class StringManager {
                 }
             }
         }
+
+        // load internationalized strings, default is defined in the properties file
+        changeLocale(properties.getProperty(DEFAULT_LANGUAGE));
     }
 
     /**
@@ -144,6 +147,15 @@ public final class StringManager {
     }
 
     /**
+     * Change the locale and reload messages
+     * @param language String containing both the language and country, e.g. en_US
+     */
+    public static void changeLocale(String language) {
+        String[] locale = language.split("_");
+        changeLocale(locale[0], locale[1]);
+    }
+
+    /**
      * Return string corresponding to the given key according the locale
      * @param key name of the property in the bundle messages
      * @return a String
@@ -151,4 +163,6 @@ public final class StringManager {
     public static String string(final String key) {
         return messages.getString(key);
     }
+
+
 }

--- a/src/main/java/fr/cnes/sonar/report/utils/StringManager.java
+++ b/src/main/java/fr/cnes/sonar/report/utils/StringManager.java
@@ -102,9 +102,6 @@ public final class StringManager {
                 }
             }
         }
-
-        // load internationalized strings, french by default
-        changeLocale("fr","FR");
     }
 
     /**


### PR DESCRIPTION
The report language is set using the command line option.  The default is set to english (based on the documentation in the code) and French can be obtained by defining this on the command line.

# Fixed issues
* Fix #44