### PR TITLE
Fix #45 - Redefine rules' severity based on active Quality Profile

### DIFF
--- a/src/main/java/fr/cnes/sonar/report/providers/QualityProfileProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/QualityProfileProvider.java
@@ -98,6 +98,17 @@ public class QualityProfileProvider extends AbstractDataProvider {
                 jo = request(request);
                 // convert json to Rule objects
                 final Rule [] tmp = (getGson().fromJson(jo.get(RULES), Rule[].class));
+
+                // Redefine the rule's severity, based on the active Quality Profile (not only the default one)
+                for (Rule r: tmp) {
+                    // If the rule is active in the Quality Profile
+                    if(jo.get("actives").getAsJsonObject().has(r.getKey())) {
+                        // Retrieve the severity set in the Quality Profile, and override the rule's default severity
+                        String severity = jo.get("actives").getAsJsonObject().get(r.getKey()).getAsJsonArray().get(0).getAsJsonObject().get("severity").toString();
+                        r.setSeverity(severity.replaceAll("\"",""));
+                    }
+                }
+
                 // add rules to the result list
                 rules.addAll(Arrays.asList(tmp));
 

--- a/src/main/java/fr/cnes/sonar/report/providers/QualityProfileProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/QualityProfileProvider.java
@@ -104,8 +104,8 @@ public class QualityProfileProvider extends AbstractDataProvider {
                     // If the rule is active in the Quality Profile
                     if(jo.get("actives").getAsJsonObject().has(r.getKey())) {
                         // Retrieve the severity set in the Quality Profile, and override the rule's default severity
-                        String severity = jo.get("actives").getAsJsonObject().get(r.getKey()).getAsJsonArray().get(0).getAsJsonObject().get("severity").toString();
-                        r.setSeverity(severity.replaceAll("\"",""));
+                        String severity = jo.get("actives").getAsJsonObject().get(r.getKey()).getAsJsonArray().get(0).getAsJsonObject().get("severity").getAsString();
+                        r.setSeverity(severity);
                     }
                 }
 

--- a/src/main/resources/requests.properties
+++ b/src/main/resources/requests.properties
@@ -36,7 +36,7 @@ GET_SONARQUBE_INFO_REQUEST = %s/api/system/status
 # Request to get the configuration file of a quality profile
 GET_QUALITY_PROFILES_CONFIGURATION_REQUEST = %s/api/qualityprofiles/export?language=%s&name=%s
 # Request to get the list of rules of a profile
-GET_QUALITY_PROFILES_RULES_REQUEST = %s/api/rules/search?qprofile=%s&f=htmlDesc,name,repo,severity,defaultDebtRemFn&ps=%d&p=%d
+GET_QUALITY_PROFILES_RULES_REQUEST = %s/api/rules/search?qprofile=%s&f=htmlDesc,name,repo,severity,defaultDebtRemFn,actives&ps=%d&p=%d&actives=true
 # Request to get the list of projects linked to a profile
 GET_QUALITY_PROFILES_PROJECTS_REQUEST = %s/api/qualityprofiles/projects?key=%s
 # Request to get the list of projects linked to a profile in SQ 5.X


### PR DESCRIPTION
# Fixed issues
* Fix #45 

# Proposed changes
* Set rules' severity based on what's defined in the active Quality Profile (not only the default one)