### PR TITLE
Set filename of plugin api zip result

### DIFF
--- a/src/main/java/fr/cnes/sonar/report/factory/ReportFactory.java
+++ b/src/main/java/fr/cnes/sonar/report/factory/ReportFactory.java
@@ -190,7 +190,7 @@ public class ReportFactory {
      * @param projectName Name of the current project
      * @return a formatted filename
      */
-    private static String formatFilename(final String propertyName, final String baseDir, final String projectName) {
+    public static String formatFilename(final String propertyName, final String baseDir, final String projectName) {
         // construct the filename by replacing date and name
         return StringManager.getProperty(propertyName)
                 .replaceFirst(BASEDIR, baseDir)

--- a/src/main/resources/report.properties
+++ b/src/main/resources/report.properties
@@ -26,6 +26,8 @@ issues.output=BASEDIR/DATE-NAME-issues-report.xlsx
 csv.output=BASEDIR/DATE-NAME-issues-report.csv
 #Issues' list in Markdown pattern, DATE and NAME are placeholders
 markdown.output=BASEDIR/DATE-NAME-analysis-report.md
+#Report archive filename's pattern, DATE and NAME are placeholders
+zip.report.output=DATE-NAME-report.zip
 #Name of the default author
 report.author=default
 #Default token


### PR DESCRIPTION
# Proposed changes
* Set the filename of the resulting zip archive of plugin API web service via [Content-Disposition](https://developer.mozilla.org/fr/docs/Web/HTTP/Headers/Content-Disposition) header
* It avoids having to rename the file simply named "report" when called from a browser, see below:

![image](https://user-images.githubusercontent.com/596867/60128571-467b8e80-9793-11e9-97bb-b9e82f27d7a2.png)
