### PR TITLE
cnes-report 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,27 +14,31 @@ jdk:
 
 env:
   - sonarqube: none
-  - sonarqube: 6.5
-  - sonarqube: 6.6
-  - sonarqube: 6.7
-  - sonarqube: 6.7.1
-  - sonarqube: 6.7.2
-  - sonarqube: 6.7.3
-  - sonarqube: 6.7.4
-  - sonarqube: 6.7.5
-  - sonarqube: 7.0
-  - sonarqube: 7.1
+  - sonarqube: 6.5-alpine
+  - sonarqube: 6.6-alpine
+  - sonarqube: 6.7-alpine
+  - sonarqube: 6.7.1-alpine
+  - sonarqube: 6.7.2-alpine
+  - sonarqube: 6.7.3-alpine
+  - sonarqube: 6.7.4-alpine
+  - sonarqube: 6.7.5-alpine
+  - sonarqube: 7.0-alpine
+  - sonarqube: 7.1-alpine
+  - sonarqube: 7.8-community
+  - sonarqube: 7.7-community
+  - sonarqube: 7.9-community
+  - sonarqube: lts
 
 script:
   - if [ $sonarqube != "none" ]; then
     mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package;
     chmod +x src/test/it/run-test.sh;mvn clean package;
     echo "Starting docker";
-    docker run --name sonarqube_${sonarqube}-alpine -d -p 127.0.0.1:9000:9000/tcp sonarqube:${sonarqube}-alpine;
+    docker run --name sonarqube_${sonarqube} -d -p 127.0.0.1:9000:9000/tcp sonarqube:${sonarqube};
     echo "Inject plugin";
-    docker cp target/sonar-cnes-report.jar sonarqube_${sonarqube}-alpine:/opt/sonarqube/extensions/plugins/;
-    docker exec sonarqube_${sonarqube}-alpine chmod 777 /opt/sonarqube/extensions/plugins/sonar-cnes-report.jar;
-    docker restart sonarqube_${sonarqube}-alpine;
+    docker cp target/sonar-cnes-report.jar sonarqube_${sonarqube}:/opt/sonarqube/extensions/plugins/;
+    docker exec sonarqube_${sonarqube} chmod 777 /opt/sonarqube/extensions/plugins/sonar-cnes-report.jar;
+    docker restart sonarqube_${sonarqube};
     echo "Waiting 5 minutes for SonarQube...";
     sleep 300;
     mvn sonar:sonar -Dsonar.host.url=http://127.0.0.1:9000 -Dsonar.login=admin -Dsonar.password=admin -Dsonar.organization=default-organization -Dsonar.branch.name= ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ jdk:
 
 env:
   - sonarqube: none
-  - sonarqube: 6.5-alpine
   - sonarqube: 6.6-alpine
   - sonarqube: 6.7-alpine
   - sonarqube: 6.7.1-alpine
@@ -24,8 +23,8 @@ env:
   - sonarqube: 6.7.5-alpine
   - sonarqube: 7.0-alpine
   - sonarqube: 7.1-alpine
-  - sonarqube: 7.8-community
   - sonarqube: 7.7-community
+  - sonarqube: 7.8-community
   - sonarqube: 7.9-community
   - sonarqube: lts
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,3 +53,14 @@ cache:
 
 notifications:
   email: false
+
+deploy:
+  provider: releases
+  api_key:
+    secure: PFc97cepts1tQHmAWMIoLUVFo3aP6o6sVVg6B+30YjguyO6SrnFf/uE+zem1ogP6S3NOcMY0xtfBM4QSHoOTWVp1C5nk7SPzvXUs/diP5J7B58Z8OhMl0vkjz2Xa4GQx6ndK07DgMUeJyxexTBatJJ47E1Y+xLHqkSbcCCALfD4LfRvAM902t9nHBcRUPONmbAX6fj2z5TRTc9AveWwwgAbfHPjsh2WvuEQ0bSttKIYO08rm4GfXiqcwcfUtBwRLij+tQEYmyj+D5ie1jfJZe61FEF9rH1bS44ARr3BMqm1Ezm6rIEYG+4f1h5xZnXjX50uYIlShH9me28+XPr7FCopOwJyim/cT4Lviypw6dki4FRtRig93+Gjj42rLXSQaL4VtA1p+KscCBrG3C4QCbIOEixtN8n/WDd1U90x3GX8X+iPxApw5pWJ/Svc7ggjh9f0WvpsFGlFowqQBsP0GrGwdDoNeu5qaHA6G1AIHses6EUcq/WZ6ZAy/cbQCNjICPIzXYSV8pBCKjnnXZWZfciZWH3Q/EghCnyyjCGLpYV2cEtHgGx50rGWQVyPHmKZZ6/B2CETWPtxpg//yXPRsTII0ssBbgFZgmeiW6Hl+TQv6AEoLK4YJhPod8XEenYKwanct2zGbOH6YH6emM0vE3HN3ldfHNRHtyhPyGsefsc0=
+  file: sonar-cnes-report.jar
+  skip_cleanup: true
+  draft: true
+  on:
+    branch: master
+    condition: $sonarqube = none

--- a/.workflow
+++ b/.workflow
@@ -1,0 +1,3 @@
+action "SonarCloud Scan" {
+  uses = "SonarSource/sonarcloud-github-action@v1.1"
+}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This tool can be used in standalone as a JAR executable (with the command line) 
 #### Get help
 Use `java -jar cnesreport.jar -h` to get the following help about cnesreport:
 ````
-usage: java -jar cnesreport.jar [-a <arg>] [-c] [-d <arg>] [-e] [-h] [-l <arg>] [-o <arg>] [-p <arg>] [-r <arg>] 
+usage: java -jar cnesreport.jar [-a <arg>] [-c] [-d <arg>] [-e] [-h] [-l <arg>] [-o <arg>] [-p <arg>] [-r <arg>]
        [-s <arg>] [-t <arg>] [-v] [-w] [-x <arg>]
 Generate editable reports for SonarQube projects.
 
@@ -89,7 +89,7 @@ To use the proxy feature be sure to set following properties:
 ###### Example
 If your JRE's proxy is not set, you can use Java flags as follow:
 ```bash
-java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42 
+java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
 -Dhttps.proxyUser=jerry -Dhttps.proxyPassword=siegel
 -jar cnesreport.jar -t xuixg5hub345xbefu -s https://example.org:9000 -p projectId
 
@@ -107,15 +107,17 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
 <table>
  <tr>
   <td><b>SonarQube / cnesreport</b></td>
-  <td><b>1.1.0</b></td>
-  <td><b>1.2.0</b></td>
-  <td><b>1.2.1</b></td>
-  <td><b>2.0.0</b></td>
-  <td><b>2.1.0</b></td>
-  <td><b>2.2.0</b></td>
+  <td><b>1.1.0<br/>Standalone only</b></td>
+  <td><b>1.2.0<br/>Standalone only</b></td>
+  <td><b>1.2.1<br/>Standalone only</b></td>
+  <td><b>2.0.0<br/>Standalone only</b></td>
+  <td><b>2.1.0<br/>Standalone only</b></b></td>
+  <td><b>2.2.0<br/>Standalone + Plugin</b></td>
+  <td><b>3.0.0<br/>Standalone + Plugin</b></b></td>
  </tr>
  <tr>
   <td><b>3.7.x (LTS)</b></td>
+  <td>-</td>
   <td>-</td>
   <td>-</td>
   <td>-</td>
@@ -131,6 +133,7 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>-</td>
   <td>-</td>
+  <td>-</td>
  </tr>
   <tr>
   <td><b>5.6.x (LTS)</b></td>
@@ -139,6 +142,7 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>X</td>
   <td>X</td>
+  <td>-</td>
   <td>-</td>
  </tr>
  <tr>
@@ -149,6 +153,7 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>X</td>
   <td>X</td>
   <td>-</td>
+  <td>-</td>
  </tr>
  <tr>
   <td><b>6.1.x</b></td>
@@ -158,6 +163,7 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>X</td>
   <td>X</td>
   <td>-</td>
+  <td>-</td>
  </tr>
  <tr>
   <td><b>6.2.x</b></td>
@@ -166,6 +172,7 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>X</td>
   <td>X</td>
+  <td>-</td>
   <td>-</td>
  </tr>
  <tr>
@@ -185,6 +192,7 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>X</td>
   <td>X</td>
   <td>-</td>
+  <td>-</td>
  </tr>
  <tr>
   <td><b>6.5.x</b></td>
@@ -194,6 +202,7 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>X</td>
   <td>X</td>
   <td>X</td>
+  <td>-</td>
  </tr>
  <tr>
   <td><b>6.6.x</b></td>
@@ -203,9 +212,11 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>X</td>
   <td>X</td>
   <td>X</td>
+  <td>X</td>
  </tr>
  <tr>
   <td><b>6.7.x (LTS)</b></td>
+  <td>X</td>
   <td>X</td>
   <td>X</td>
   <td>X</td>
@@ -220,6 +231,7 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>X</td>
   <td>X</td>
+  <td>(standalone only)</td>
   <td>X</td>
  </tr>
  <tr>
@@ -229,6 +241,7 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>X</td>
   <td>X</td>
+  <td>(standalone only)</td>
   <td>X</td>
  </tr>
  <tr>
@@ -238,6 +251,7 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>X</td>
   <td>X</td>
+  <td>(standalone only)</td>
   <td>X</td>
  </tr>
  <tr>
@@ -247,6 +261,37 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>X</td>
   <td>X</td>
+  <td>(standalone only)</td>
+  <td>X</td>
+ </tr>
+ <tr>
+  <td><b>7.7</b></td>
+  <td>-</td>
+  <td>-</td>
+  <td>-</td>
+  <td>X</td>
+  <td>X</td>
+  <td>(standalone only)</td>
+  <td>X</td>
+ </tr>
+ <tr>
+  <td><b>7.8</b></td>
+  <td>-</td>
+  <td>-</td>
+  <td>-</td>
+  <td>X</td>
+  <td>X</td>
+  <td>(standalone only)</td>
+  <td>X</td>
+ </tr>
+ <tr>
+  <td><b>7.9.x (LTS)</b></td>
+  <td>-</td>
+  <td>-</td>
+  <td>-</td>
+  <td>X</td>
+  <td>X</td>
+  <td>(standalone only)</td>
   <td>X</td>
  </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
 ### Compatibility matrix
 <table>
  <tr>
-  <td><b>SonarQube / cnesreport</b></td>
+  <td><b>cnesreport <br>\<br> SonarQube</b></td>
   <td><b>1.1.0<br/>Standalone only</b></td>
   <td><b>1.2.0<br/>Standalone only</b></td>
   <td><b>1.2.1<br/>Standalone only</b></td>
@@ -142,7 +142,7 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>X</td>
   <td>X</td>
-  <td>-</td>
+  <td>(standalone only)</td>
   <td>-</td>
  </tr>
  <tr>
@@ -152,7 +152,7 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>X</td>
   <td>X</td>
-  <td>-</td>
+  <td>(standalone only)</td>
   <td>-</td>
  </tr>
  <tr>
@@ -162,7 +162,7 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>X</td>
   <td>X</td>
-  <td>-</td>
+  <td>(standalone only)</td>
   <td>-</td>
  </tr>
  <tr>
@@ -172,7 +172,7 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>X</td>
   <td>X</td>
-  <td>-</td>
+  <td>(standalone only)</td>
   <td>-</td>
  </tr>
  <tr>
@@ -182,6 +182,7 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>X</td>
   <td>X</td>
+  <td>(standalone only)</td>
   <td>-</td>
  </tr>
  <tr>
@@ -191,7 +192,7 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>X</td>
   <td>X</td>
-  <td>-</td>
+  <td>(standalone only)</td>
   <td>-</td>
  </tr>
  <tr>

--- a/src/main/java/fr/cnes/sonar/plugin/tools/ZipFolder.java
+++ b/src/main/java/fr/cnes/sonar/plugin/tools/ZipFolder.java
@@ -38,7 +38,7 @@ public class ZipFolder {
      * @param zipFilePath output path
      * @throws IOException
      */
-    public static <Stream> void pack(String sourceDirPath, String zipFilePath) throws IOException {
+    public static void pack(String sourceDirPath, String zipFilePath) throws IOException {
         Path p = Files.createFile(Paths.get(zipFilePath));
         java.util.stream.Stream<Path> file = null;
         try (ZipOutputStream zs = new ZipOutputStream(Files.newOutputStream(p))) {

--- a/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
+++ b/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
@@ -100,13 +100,11 @@ public class ExportTask implements RequestHandler {
         } catch (BadSonarQubeRequestException e) {
             try(JsonWriter jsonWriter = response.newJsonWriter()){
                 jsonWriter.beginObject();
-                jsonWriter.prop("error", "This project can't be exported, please check your token.");
+                jsonWriter.prop("error", PluginStringManager.getProperty("api.tokenerror"));
                 jsonWriter.endObject();
             }
 
         }
-
-
 
         FileTools.deleteFolder(outputDirectory);
     }

--- a/src/main/java/fr/cnes/sonar/report/exporters/CSVExporter.java
+++ b/src/main/java/fr/cnes/sonar/report/exporters/CSVExporter.java
@@ -43,28 +43,27 @@ public class CSVExporter implements IExporter {
         // Opening file
         File file = new File(filePath);
         FileWriter outputfile = new FileWriter(file);
-        CSVPrinter csvPrinter = new CSVPrinter(outputfile, CSVFormat.EXCEL.withDelimiter('\t'));
+        try(CSVPrinter csvPrinter = new CSVPrinter(outputfile, CSVFormat.EXCEL.withDelimiter('\t'))){
 
-        List<Map> allIssues = report.getRawIssues();
+          List<Map> allIssues = report.getRawIssues();
 
-        // Extracting headers
-        List<String> headers = XlsXTools.extractHeader(allIssues);
+          // Extracting headers
+          List<String> headers = XlsXTools.extractHeader(allIssues);
 
-        // Writing headers
-        csvPrinter.printRecord(headers);
+          // Writing headers
+          csvPrinter.printRecord(headers);
 
-        // Writing lines
-        List<String> line;
-        for(Map<String, String> issue:allIssues){
-            line = new ArrayList<>();
-            for(String col: headers){
-                line.add(issue.get(col));
-            }
-            csvPrinter.printRecord(line);
+          // Writing lines
+          List<String> line;
+          for(Map<String, String> issue:allIssues){
+              line = new ArrayList<>();
+              for(String col: headers){
+                  line.add(issue.get(col));
+              }
+              csvPrinter.printRecord(line);
+          }
         }
 
-        // closing file
-        csvPrinter.close();
         return file;
     }
 }

--- a/src/main/java/fr/cnes/sonar/report/exporters/MarkdownExporter.java
+++ b/src/main/java/fr/cnes/sonar/report/exporters/MarkdownExporter.java
@@ -122,7 +122,6 @@ public class MarkdownExporter implements IExporter {
             // Saving output
             try(FileWriter fileWriter = new FileWriter(path)){
               fileWriter.write(output);
-              fileWriter.close();
             }
             return file;
         }

--- a/src/main/java/fr/cnes/sonar/report/exporters/MarkdownExporter.java
+++ b/src/main/java/fr/cnes/sonar/report/exporters/MarkdownExporter.java
@@ -120,9 +120,10 @@ public class MarkdownExporter implements IExporter {
 
 
             // Saving output
-            FileWriter fileWriter = new FileWriter(path);
-            fileWriter.write(output);
-            fileWriter.close();
+            try(FileWriter fileWriter = new FileWriter(path)){
+              fileWriter.write(output);
+              fileWriter.close();
+            }
             return file;
         }
 

--- a/src/main/java/fr/cnes/sonar/report/providers/ComponentProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/ComponentProvider.java
@@ -120,7 +120,6 @@ public class ComponentProvider extends AbstractDataProvider {
 
         // for each metric
         for(Object metric: XlsXTools.extractHeader(componentsList)){
-        //for(Object metric:metrics){
             // if metric is numerical
             if (isCountableMetric(metric.toString())) {
                 // Get min, max and mean of this metric on the current project

--- a/src/main/java/fr/cnes/sonar/report/providers/ComponentProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/ComponentProvider.java
@@ -116,7 +116,6 @@ public class ComponentProvider extends AbstractDataProvider {
 
         Map<String, Double> map = new HashMap();
         // Use first component to gets all metrics names
-        Object[] metrics = componentsList.get(0).keySet().toArray();
 
         // for each metric
         for(Object metric: XlsXTools.extractHeader(componentsList)){

--- a/src/main/java/fr/cnes/sonar/report/providers/ComponentProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/ComponentProvider.java
@@ -20,6 +20,7 @@ package fr.cnes.sonar.report.providers;
 import com.google.gson.JsonObject;
 import fr.cnes.sonar.report.exceptions.BadSonarQubeRequestException;
 import fr.cnes.sonar.report.exceptions.SonarQubeException;
+import fr.cnes.sonar.report.exporters.xlsx.XlsXTools;
 import fr.cnes.sonar.report.model.Component;
 import fr.cnes.sonar.report.model.SonarQubeServer;
 import org.apache.commons.lang3.math.NumberUtils;
@@ -118,7 +119,8 @@ public class ComponentProvider extends AbstractDataProvider {
         Object[] metrics = componentsList.get(0).keySet().toArray();
 
         // for each metric
-        for(Object metric:metrics){
+        for(Object metric: XlsXTools.extractHeader(componentsList)){
+        //for(Object metric:metrics){
             // if metric is numerical
             if (isCountableMetric(metric.toString())) {
                 // Get min, max and mean of this metric on the current project
@@ -134,7 +136,7 @@ public class ComponentProvider extends AbstractDataProvider {
     private boolean isCountableMetric(String metric){
         // Get first non-null value of metrics
         int i=0;
-        while(i<componentsList.size() && componentsList.get(i) == null){
+        while(i<componentsList.size() && (componentsList.get(i) == null || componentsList.get(i).get(metric) == null)){
             ++i;
         }
 

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -32,3 +32,5 @@ api.report.args.author=author
 api.report.args.description.author=Author of the report
 api.report.args.token=token
 api.report.args.description.token=Authentication token (for protected project)
+
+api.tokenerror=This project can't be exported, please check your token.

--- a/src/main/resources/requests.properties
+++ b/src/main/resources/requests.properties
@@ -18,13 +18,13 @@
 #Number max of results per page
 MAX_PER_PAGE_SONARQUBE = 500
 # Request to get the list of components and their metrics
-GET_COMPONENTS_REQUEST = %s/api/measures/component_tree?baseComponentKey=%s&metricKeys=ncloc,comment_lines_density,coverage,complexity,cognitive_complexity,duplicated_lines_density&p=%s&ps=%s
+GET_COMPONENTS_REQUEST = %s/api/measures/component_tree?component=%s&metricKeys=ncloc,comment_lines_density,coverage,complexity,cognitive_complexity,duplicated_lines_density&p=%s&ps=%s
 # Request to get the list of metrics
-GET_MEASURES_REQUEST = %s/api/measures/component?componentKey=%s&metricKeys=ncloc,violations,ncloc_language_distribution,duplicated_lines_density,coverage,sqale_rating,reliability_rating,security_rating,alert_status,complexity,function_complexity,file_complexity,class_complexity,blocker_violations,critical_violations,major_violations,minor_violations,info_violations,new_violations,bugs,vulnerabilities,code_smells
+GET_MEASURES_REQUEST = %s/api/measures/component?component=%s&metricKeys=ncloc,violations,ncloc_language_distribution,duplicated_lines_density,coverage,sqale_rating,reliability_rating,security_rating,alert_status,complexity,function_complexity,file_complexity,class_complexity,blocker_violations,critical_violations,major_violations,minor_violations,info_violations,new_violations,bugs,vulnerabilities,code_smells
 # Request for getting a specific project
-GET_PROJECT_REQUEST = %s/api/navigation/component?componentKey=%s
+GET_PROJECT_REQUEST = %s/api/navigation/component?component=%s
 # Request information about a project where quality gate is available
-GET_QUALITY_GATE_REQUEST=%s/api/navigation/component?componentKey=%s
+GET_QUALITY_GATE_REQUEST=%s/api/navigation/component?component=%s
 # Request to get the list of quality gates
 GET_QUALITY_GATES_REQUEST = %s/api/qualitygates/list
 # Request to get the details of a quality gate
@@ -44,8 +44,8 @@ GET_QUALITY_PROFILES_PROJECTS_REQUEST = %s/api/qualityprofiles/projects?key=%s
 # Request to get the list of projects linked to a profile in SQ 5.X
 GET_PROJECT_QUALITY_PROFILES_REQUEST = %s/api/qualityprofiles/search?projectKey=%s
 # Request to get the list of issues linked to a project
-GET_ISSUES_REQUEST = %s/api/issues/search?projectKeys=%s&facets=types,rules,severities,directories,fileUuids,tags&ps=%d&p=%d&additionalFields=rules,comments&resolved=%s
+GET_ISSUES_REQUEST = %s/api/issues/search?projects=%s&facets=types,rules,severities,directories,fileUuids,tags&ps=%d&p=%d&additionalFields=rules,comments&resolved=%s
 # Request to get the list of a project's facets
-GET_FACETS_REQUEST = %s/api/issues/search?projectKeys=%s&resolved=false&facets=rules,severities,types&ps=1&p=1
+GET_FACETS_REQUEST = %s/api/issues/search?projects=%s&resolved=false&facets=rules,severities,types&ps=1&p=1
 # Request to get the list of a project's facets
 GET_LANGUAGES = %s/api/languages/list

--- a/src/main/resources/static/report.js
+++ b/src/main/resources/static/report.js
@@ -29,16 +29,9 @@ window.registerExtension('cnesreport/report', function (options) {
         ).then(function (response) {
             // on success
             // we put each quality gate in the list
-            $.each(response, function (i, item) {
-                // we create a new option for each quality gate
-                // in the json response
-                var option = $('<option>', {
-                                 value: item.k,
-                                 text : item.nm + ' [' + item.k + ']'
-                             });
-                // we add it to the drop down list
-                $('#key').append(option);
-            });
+            for (i=0;i<response.length;++i){
+                document.getElementById("key").innerHTML += "<option value='"+response[i].k+"'>"+response[i].nm+"</option>"
+            }
         });
 
         window.SonarRequest.post(
@@ -47,13 +40,13 @@ window.registerExtension('cnesreport/report', function (options) {
                     window.SonarRequest.postJSON(
                         '/api/user_tokens/generate', {name: "cnes-report"}
                     ).then(function (response) {
-                        $('#token_cnesreport').val(response.token)
+                        document.getElementById("token_cnesreport").value = response.token;
                         window.SonarRequest.getJSON(
                             '/api/users/search',
                             {"q":response.login}
                         ).then(function (response) {
                             // on success
-                            $('#author').val(response.users[0].name);
+                            document.getElementById("author").value = response.users[0].name;
                         });
                     });
 
@@ -69,10 +62,45 @@ window.registerExtension('cnesreport/report', function (options) {
         template.setAttribute("id", "template");
         options.el.appendChild(template);
         // retrieve template from html
-        $('#template').load('../../static/cnesreport/templates/reportForm.html', function(){
-            // fill out project's drop down list
-            initProjectsDropDownList();
-        });
+
+        const reportForm = `
+         <div class="page-wrapper-simple"><div class="page-simple">
+           <h1 class="maintenance-title text-center">Generate a report</h1>
+           <form id="generation-form" action="../../api/cnesreport/report" method="get">
+            <div class='forminput'>
+               <label for="key" id="keyLabel" class="login-label" style="display: block;"><strong>Project key</strong></label>
+               <select id="key"
+                       name="key"
+                       class="login-input" required></select>
+             </div>     <div class='forminput'>
+               <label for="author" id="authorLabel" class="login-label" style="display: block;"><strong>Author</strong></label>
+               <input   type="text"
+                        id="author"
+                        name="author"
+                        class="login-input"
+                        maxlength="255"
+                        required
+                        placeholder="Report's author">
+               <input type="hidden" name="token" id="token_cnesreport" value="noauth"/>
+
+               <div id="loading" class="text-center overflow-hidden" style="margin-bottom: 1em; display: none;">
+                   <img src="../../static/cnesreport/images/loader.gif" alt="Working..."/>
+               </div>
+            </div><br />
+               <input id="generation" name="generation" type="submit" value="Generate"><br />
+               <em style="color:grey;">This operation may take some time, please wait while the report is being generated.</em>
+
+           </form>
+         </div></div>
+           <style>
+                .forminput select, .forminput input{
+                    width:100%;
+                }
+           </style>
+           `;
+         document.getElementById("template").innerHTML=reportForm
+         initProjectsDropDownList();
+
 
     }
 

--- a/src/test/ut/java/fr/cnes/sonar/report/ExportersTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/ExportersTest.java
@@ -24,6 +24,7 @@ import fr.cnes.sonar.report.exporters.MarkdownExporter;
 import fr.cnes.sonar.report.exporters.XmlExporter;
 import fr.cnes.sonar.report.exporters.docx.DocXExporter;
 import fr.cnes.sonar.report.exporters.xlsx.XlsXExporter;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -45,7 +46,7 @@ public class ExportersTest extends CommonTest {
     public void docxExportTest() throws Exception {
         final DocXExporter de = new DocXExporter();
 
-        de.export(report, TARGET+"/test.docx", "");
+        Assert.assertNotNull(de.export(report, TARGET+"/test.docx", ""));
     }
 
     /**
@@ -57,7 +58,7 @@ public class ExportersTest extends CommonTest {
     public void xlsxExportTest() throws Exception {
         final XlsXExporter xe = new XlsXExporter();
 
-        xe.export(report, TARGET+"/test.xlsx", "");
+        Assert.assertNotNull(xe.export(report, TARGET+"/test.xlsx", ""));
     }
 
     /**
@@ -69,7 +70,7 @@ public class ExportersTest extends CommonTest {
     public void jsonExportTest() throws Exception {
         final JsonExporter je = new JsonExporter();
 
-        je.export("{field:'value'}", TARGET, "test.xml");
+        Assert.assertNotNull(je.export("{field:'value'}", TARGET, "test.xml"));
     }
 
     /**
@@ -81,7 +82,7 @@ public class ExportersTest extends CommonTest {
     public void xmlExportTest() throws Exception {
         final XmlExporter xe = new XmlExporter();
 
-        xe.export("<tag>value</tag>", TARGET, "test.json");
+        Assert.assertNotNull(xe.export("<tag>value</tag>", TARGET, "test.json"));
     }
 
     /**
@@ -93,7 +94,7 @@ public class ExportersTest extends CommonTest {
     public void mdExportTest() throws Exception {
         final MarkdownExporter xe = new MarkdownExporter();
 
-        xe.export(report, TARGET+"test.md", "test.md");
+        Assert.assertNotNull(xe.export(report, TARGET+"test.md", "test.md"));
     }
     /**
      * Assert that there are no exception in a normal use
@@ -104,7 +105,7 @@ public class ExportersTest extends CommonTest {
     public void csvExportTest() throws Exception {
         final CSVExporter xe = new CSVExporter();
 
-        xe.export(report, TARGET+"test.csv", "test.csv");
+        Assert.assertNotNull(xe.export(report, TARGET+"test.csv", "test.csv"));
     }
 
     /**

--- a/src/test/ut/java/fr/cnes/sonar/report/factory/ProviderFactoryTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/factory/ProviderFactoryTest.java
@@ -1,7 +1,6 @@
 package fr.cnes.sonar.report.factory;
 
 import fr.cnes.sonar.report.CommonTest;
-import fr.cnes.sonar.report.model.SonarQubeServer;
 import fr.cnes.sonar.report.providers.*;
 import org.junit.Assert;
 import org.junit.Test;


### PR DESCRIPTION
Update cnes-report to provide SonarQube 7.9LTS support.

# Fixed issues
* Fix #65 - cnes-report is now working with SonarQube 7 as plugin.
* Fix #68 - deprecated api calls are removed.
* Fix #72 - return a clean error when token is invalid
* Fix: error in metrics stats (docx report) when some file can't provide metrics.
* Fix: bad practice in file opening (raised by sonar), replace `open` with `try-with-ressources`.
* Fix: Blocker Issues (SonarCloud)
* Fix: Build fails on pull requests

# New
* Use the [SonarCloud app](https://github.com/marketplace/actions/sonarcloud-scan)