### PR TITLE
cnes-report 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
     sleep 300;
     mvn sonar:sonar -Dsonar.host.url=http://127.0.0.1:9000 -Dsonar.login=admin -Dsonar.password=admin -Dsonar.organization=default-organization -Dsonar.branch.name= ;
     src/test/it/run-test.sh;
-    wget "http://127.0.0.1:9000/api/cnesreport/report?key=fr.cnes.sonar%3Acnesreport&author=travis-ci&token=noauth";
+    wget "http://localhost:9000/api/cnesreport/report?key=fr.cnes.sonar%3Acnesreport&author=travis-ci&token=noauth";
     else mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ script:
   - if [ $sonarqube != "none" ]; then
     mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package;
     chmod +x src/test/it/run-test.sh;mvn clean package;
-    mvn sonar-packaging:check;
-    mvn sonar-packaging:sonar-plugin;
     echo "Starting docker";
     docker run --name sonarqube_${sonarqube}-alpine -d -p 127.0.0.1:9000:9000/tcp sonarqube:${sonarqube}-alpine;
     echo "Inject plugin";

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
     docker restart sonarqube_${sonarqube}-alpine;
     echo "Waiting 5 minutes for SonarQube...";
     sleep 300;
-    mvn sonar:sonar -Dsonar.host.url=http://127.0.0.1:9000 -Dsonar.login=admin -Dsonar.password=admin -Dsonar.organization=default-organization -Dsonar.branch= ;
+    mvn sonar:sonar -Dsonar.host.url=http://127.0.0.1:9000 -Dsonar.login=admin -Dsonar.password=admin -Dsonar.organization=default-organization -Dsonar.branch.name= ;
     src/test/it/run-test.sh;
     else mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
     echo "Starting docker";
     docker run --name sonarqube_${sonarqube}-alpine -d -p 127.0.0.1:9000:9000/tcp sonarqube:${sonarqube}-alpine;
     echo "Inject plugin";
-    docker cp target/cnesreport-plugin.jar sonarqube_${sonarqube}-alpine:/opt/sonarqube/extensions/plugins/;
+    docker cp target/cnesreport-*.jar sonarqube_${sonarqube}-alpine:/opt/sonarqube/extensions/plugins/;
     docker exec sonarqube_${sonarqube}-alpine chmod 777 /opt/sonarqube/extensions/plugins/cnesreport-plugin.jar;
     docker restart sonarqube_${sonarqube}-alpine;
     echo "Waiting 5 minutes for SonarQube...";

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ script:
     echo "Starting docker";
     docker run --name sonarqube_${sonarqube}-alpine -d -p 127.0.0.1:9000:9000/tcp sonarqube:${sonarqube}-alpine;
     echo "Inject plugin";
-    docker cp target/cnesreport-*.jar sonarqube_${sonarqube}-alpine:/opt/sonarqube/extensions/plugins/;
-    docker exec sonarqube_${sonarqube}-alpine chmod 777 /opt/sonarqube/extensions/plugins/cnesreport-plugin.jar;
+    docker cp target/sonar-cnes-report.jar sonarqube_${sonarqube}-alpine:/opt/sonarqube/extensions/plugins/;
+    docker exec sonarqube_${sonarqube}-alpine chmod 777 /opt/sonarqube/extensions/plugins/sonar-cnes-report.jar;
     docker restart sonarqube_${sonarqube}-alpine;
     echo "Waiting 5 minutes for SonarQube...";
     sleep 300;

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ script:
     sleep 300;
     mvn sonar:sonar -Dsonar.host.url=http://127.0.0.1:9000 -Dsonar.login=admin -Dsonar.password=admin -Dsonar.organization=default-organization -Dsonar.branch.name= ;
     src/test/it/run-test.sh;
+    wget "http://127.0.0.1:9000/api/cnesreport/report?key=fr.cnes.sonar%3Acnesreport&author=travis-ci&token=noauth";
     else mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar;
     fi
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,22 @@ SonarQube is an open platform to manage code quality. This program can export co
 
 This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 3 of the License, or (at your option) any later version.
 
+This tool can be used in standalone as a JAR executable (with the command line) or as a Sonarqube plugin.
+
 ### Quickstart
 - Setup a SonarQube instance.
 - Run an analysis with sonar-scanner, maven, gradle, msbuild, etc.
-- Execute cnesreport thanks to the command line.
+- Execute cnesreport:
+   - In standalone, thanks to command line
+   - In plugin mode, copy jar in `/opt/sonarqube/plugins`, restart sonarqube, then click on "CNES Report" link.
 
 #### Installation
+##### Standalone mode
 **cnesreport** does not need any installation. It is a portable Java application you can copy and run according to following examples. The only requirement is an **up-to-date JRE (>1.8)**.
+
+##### Plugin mode (Since 2.2.0)
+- Copy the sonar-cnes-report.jar in the plugin folder of sonarqube (On linux path should be like `/opt/sonarqube/plugins`)
+- Restart sonarqube (On linux: `sudo service sonar restart`)
 
 #### Get help
 Use `java -jar cnesreport.jar -h` to get the following help about cnesreport:
@@ -54,7 +63,9 @@ This is the minimal usage of cnesreport. This example export (report + spreadshe
 java -jar cnesreport.jar -p projectId
 ````
 
-##### Advanced usage
+If you have installed cnes-report in your sonarqube: open web interface, click on "CNES Report" then choose a project.
+
+##### Advanced usage (standalone)
 If you are using a secured instance of SonarQube, you can provide a SonarQube authentication token thanks to `-t` option and specify the url of the SonarQube instance with `-s`. The internal template for the text report will be replace by the one given through `-r` option.
 ````
 java -jar cnesreport.jar -t xuixg5hub345xbefu -s https://example.org:9000 -p projectId -r ./template.docx
@@ -94,9 +105,13 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td><b>1.2.0</b></td>
   <td><b>1.2.1</b></td>
   <td><b>2.0.0</b></td>
+  <td><b>2.1.0</b></td>
+  <td><b>2.2.0</b></td>
  </tr>
  <tr>
   <td><b>3.7.x (LTS)</b></td>
+  <td>-</td>
+  <td>-</td>
   <td>-</td>
   <td>-</td>
   <td>-</td>
@@ -108,6 +123,8 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>-</td>
   <td>-</td>
+  <td>-</td>
+  <td>-</td>
  </tr>
   <tr>
   <td><b>5.6.x (LTS)</b></td>
@@ -115,6 +132,8 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>-</td>
   <td>X</td>
+  <td>X</td>
+  <td>-</td>
  </tr>
  <tr>
   <td><b>6.0.x</b></td>
@@ -122,6 +141,8 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>-</td>
   <td>X</td>
+  <td>X</td>
+  <td>-</td>
  </tr>
  <tr>
   <td><b>6.1.x</b></td>
@@ -129,6 +150,8 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>-</td>
   <td>X</td>
+  <td>X</td>
+  <td>-</td>
  </tr>
  <tr>
   <td><b>6.2.x</b></td>
@@ -136,6 +159,8 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>-</td>
   <td>X</td>
+  <td>X</td>
+  <td>-</td>
  </tr>
  <tr>
   <td><b>6.3.x</b></td>
@@ -143,6 +168,8 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>-</td>
   <td>X</td>
+  <td>X</td>
+  <td>-</td>
  </tr>
  <tr>
   <td><b>6.4.x</b></td>
@@ -150,12 +177,16 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>-</td>
   <td>X</td>
+  <td>X</td>
+  <td>-</td>
  </tr>
  <tr>
   <td><b>6.5.x</b></td>
   <td>-</td>
   <td>-</td>
   <td>-</td>
+  <td>X</td>
+  <td>X</td>
   <td>X</td>
  </tr>
  <tr>
@@ -164,9 +195,13 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>-</td>
   <td>X</td>
+  <td>X</td>
+  <td>X</td>
  </tr>
  <tr>
   <td><b>6.7.x (LTS)</b></td>
+  <td>X</td>
+  <td>X</td>
   <td>X</td>
   <td>X</td>
   <td>X</td>
@@ -178,12 +213,16 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>-</td>
   <td>X</td>
+  <td>X</td>
+  <td>X</td>
  </tr>
  <tr>
   <td><b>7.1</b></td>
   <td>-</td>
   <td>-</td>
   <td>-</td>
+  <td>X</td>
+  <td>X</td>
   <td>X</td>
  </tr>
  <tr>
@@ -192,12 +231,16 @@ java -Dhttps.proxyHost=https://myproxy -Dhttps.proxyPort=42
   <td>-</td>
   <td>-</td>
   <td>X</td>
+  <td>X</td>
+  <td>X</td>
  </tr>
  <tr>
   <td><b>7.3</b></td>
   <td>-</td>
   <td>-</td>
   <td>-</td>
+  <td>X</td>
+  <td>X</td>
   <td>X</td>
  </tr>
 </table>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>fr.cnes.sonar</groupId>
     <artifactId>cnesreport</artifactId>
-    <version>2.2.0</version>
+    <version>3.0.0</version>
     <packaging>sonar-plugin</packaging>
 
     <name>SonarQube CNES Report</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>fr.cnes.sonar</groupId>
     <artifactId>cnesreport</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>sonar-plugin</packaging>
 
     <name>SonarQube CNES Report</name>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <junit.version>4.12</junit.version>
         <jacoco.version>0.8.0</jacoco.version>
-        <sonar.apiVersion>6.7</sonar.apiVersion>
+        <sonar.apiVersion>6.5</sonar.apiVersion>
         <sonar-packaging-maven-plugin.version>1.18.0.372</sonar-packaging-maven-plugin.version>
         <sonar.pluginKey>cnesreport</sonar.pluginKey>
         <sonar.pluginUrl>https://github.com/lequal/sonar-cnes-report</sonar.pluginUrl>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>fr.cnes.sonar</groupId>
     <artifactId>cnesreport</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0</version>
     <packaging>sonar-plugin</packaging>
 
     <name>SonarQube CNES Report</name>

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,9 @@
                 <artifactId>sonar-packaging-maven-plugin</artifactId>
                 <version>${sonar-packaging-maven-plugin.version}</version>
                 <extensions>true</extensions>
+                <configuration>
+                    <jarName>sonar-cnes-report</jarName>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <junit.version>4.12</junit.version>
         <jacoco.version>0.8.0</jacoco.version>
-        <sonar.apiVersion>6.7.6</sonar.apiVersion>
+        <sonar.apiVersion>6.7</sonar.apiVersion>
         <sonar-packaging-maven-plugin.version>1.18.0.372</sonar-packaging-maven-plugin.version>
         <sonar.pluginKey>cnesreport</sonar.pluginKey>
         <sonar.pluginUrl>https://github.com/lequal/sonar-cnes-report</sonar.pluginUrl>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>fr.cnes.sonar</groupId>
     <artifactId>cnesreport</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0</version>
     <packaging>sonar-plugin</packaging>
 
     <name>SonarQube CNES Report</name>

--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,10 @@
     <groupId>fr.cnes.sonar</groupId>
     <artifactId>cnesreport</artifactId>
     <version>2.2.0-SNAPSHOT</version>
+    <packaging>sonar-plugin</packaging>
 
-    <name>SonarQube CNES Report App</name>
-    <description>CNES app for SonarQube that allows users to export analysis reports as OpenXML.</description>
+    <name>SonarQube CNES Report</name>
+    <description>CNES app/plugin for SonarQube that allows users to export analysis reports as OpenXML, Markdown and CSV.</description>
     <organization>
         <name>CNES</name>
         <url>https://cnes.fr/</url>
@@ -28,12 +29,22 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <sonar.apiVersion>6.5</sonar.apiVersion>
         <jdk.min.version>1.8</jdk.min.version>
-        <pluginUrl>https://cnes.fr</pluginUrl>
-        <pluginOrganizationName>CNES</pluginOrganizationName>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <junit.version>4.12</junit.version>
+        <jacoco.version>0.8.0</jacoco.version>
+        <sonar.apiVersion>6.7.6</sonar.apiVersion>
+        <sonar-packaging-maven-plugin.version>1.18.0.372</sonar-packaging-maven-plugin.version>
+        <sonar.pluginKey>cnesreport</sonar.pluginKey>
+        <sonar.pluginUrl>https://github.com/lequal/sonar-cnes-report</sonar.pluginUrl>
+        <sonar.pluginOrganizationName>CNES</sonar.pluginOrganizationName>
+        <sonar.sources>src/main/java</sonar.sources>
+        <sonar.test>src/test/java</sonar.test>
+        <sonar.skipDependenciesPackaging>true</sonar.skipDependenciesPackaging>
+        <sonar.useChildFirstClassLoader>true</sonar.useChildFirstClassLoader>
+        <sonar.pluginClass>fr.cnes.sonar.plugin.ReportSonarPlugin</sonar.pluginClass>
+        <app.mainClass>fr.cnes.sonar.report.ReportCommandLine</app.mainClass>
     </properties>
 
     <licenses>
@@ -48,22 +59,29 @@
         <developer>
             <id>begarco</id>
             <name>Benoît Garçon</name>
-            <email>benoit.garcon@outlook.com</email>
-            <organization>CNES</organization>
-            <organizationUrl>https://cnes.fr/</organizationUrl>
+        </developer>
+        <developer>
+            <id>Sancretor</id>
+            <name>Alexis Chatillon</name>
+        </developer>
+        <developer>
+            <id>louisjdmartin</id>
+            <name>Louis Martin</name>
         </developer>
     </developers>
-    <packaging>sonar-plugin</packaging>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
             <version>1.5</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.25</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.sonarsource.sonarqube</groupId>
@@ -82,18 +100,21 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.6</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <!-- https://mvnrepository.com/artifact/commons-cli/commons-cli -->
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.4</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.8.1</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <!-- packaged with the plugin -->
@@ -117,10 +138,15 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <!-- openxml generation -->
             <groupId>org.apache.poi</groupId>
-            <artifactId>ooxml-schemas</artifactId>
-            <version>1.4</version>
+            <artifactId>poi-ooxml-schemas</artifactId>
+            <version>4.1.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>ooxml-security</artifactId>
+            <version>1.1</version>
             <scope>compile</scope>
         </dependency>
         <!-- unit report -->
@@ -131,7 +157,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>5.3.1</version>
@@ -142,54 +167,47 @@
     <build>
         <testSourceDirectory>src/test/ut/java</testSourceDirectory>
         <plugins>
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <mainClass>fr.cnes.sonar.report.ReportCommandLine</mainClass>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-                        </manifest>
-                    </archive>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <finalName>cnesreport</finalName>
-                    <appendAssemblyId>false</appendAssemblyId>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>make-assembly</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+
             <plugin>
                 <groupId>org.sonarsource.sonar-packaging-maven-plugin</groupId>
                 <artifactId>sonar-packaging-maven-plugin</artifactId>
-                <version>1.17</version>
+                <version>${sonar-packaging-maven-plugin.version}</version>
                 <extensions>true</extensions>
-                <configuration>
-                    <pluginKey>cnesreport</pluginKey>
-                    <pluginClass>fr.cnes.sonar.plugin.ReportSonarPlugin</pluginClass>
-                    <skipDependenciesPackaging>false</skipDependenciesPackaging>
-                    <finalName>cnesreport-plugin</finalName>
-                </configuration>
             </plugin>
+
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>${app.mainClass}</mainClass>
+                                </transformer>
+                            </transformers>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <!--<minimizeJar>true</minimizeJar>-->
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.2</version>
+                <version>3.5.1</version>
                 <configuration>
                     <source>${jdk.min.version}</source>
                     <target>${jdk.min.version}</target>
                 </configuration>
             </plugin>
+
             <plugin>
                 <!-- UTF-8 bundles are not supported by Java, so they must be converted during build -->
                 <groupId>org.codehaus.mojo</groupId>
@@ -212,6 +230,41 @@
                     <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>post-unit-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Sets the path to the file which contains the execution data. -->
+                            <dataFile>target/jacoco.exec</dataFile>
+                            <!-- Sets the output directory for the code coverage report. -->
+                            <outputDirectory>target/jacoco-ut</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/src/main/java/fr/cnes/sonar/plugin/tools/FileTools.java
+++ b/src/main/java/fr/cnes/sonar/plugin/tools/FileTools.java
@@ -19,9 +19,14 @@ package fr.cnes.sonar.plugin.tools;
 
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 
 public class FileTools {
 
+    private FileTools(){
+        throw new IllegalStateException("Utility class");
+    }
     /**
      * Delete a folder
      * WARNING: Recursive call, maybe it's not a good idea for large folder with lots of subfolder.
@@ -34,8 +39,18 @@ public class FileTools {
         for(String f: files != null ? files : new String[0]){
             toDelete = new File(f);
             if (toDelete.isDirectory()) deleteFolder(toDelete);
-            else toDelete.delete();
+            else {
+                try {
+                    Files.delete(toDelete.toPath());
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
         }
-        folder.delete();
+        try {
+            Files.delete(folder.toPath());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/main/java/fr/cnes/sonar/plugin/tools/FileTools.java
+++ b/src/main/java/fr/cnes/sonar/plugin/tools/FileTools.java
@@ -21,6 +21,7 @@ package fr.cnes.sonar.plugin.tools;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.logging.Logger;
 
 public class FileTools {
 
@@ -43,14 +44,17 @@ public class FileTools {
                 try {
                     Files.delete(toDelete.toPath());
                 } catch (IOException e) {
-                    e.printStackTrace();
+
+                    Logger LOGGER = Logger.getLogger(FileTools.class.getName());
+                    LOGGER.warning(e.getMessage());
                 }
             }
         }
         try {
             Files.delete(folder.toPath());
         } catch (IOException e) {
-            e.printStackTrace();
+            Logger LOGGER = Logger.getLogger(FileTools.class.getName());
+            LOGGER.warning(e.getMessage());
         }
     }
 }

--- a/src/main/java/fr/cnes/sonar/plugin/tools/PluginStringManager.java
+++ b/src/main/java/fr/cnes/sonar/plugin/tools/PluginStringManager.java
@@ -25,6 +25,9 @@ import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * String manager for cnes-report in plugin mode
+ */
 public class PluginStringManager {
     private static Properties properties = new Properties();
     protected static final Logger LOGGER = Logger.getLogger(PluginStringManager.class.getCanonicalName());
@@ -39,8 +42,7 @@ public class PluginStringManager {
                 // load properties from the stream in an adapted structure
                 properties.load(input);
             }
-        } catch (
-        IOException e) {
+        } catch (IOException e) {
             // it logs all the stack trace
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
         }

--- a/src/main/java/fr/cnes/sonar/plugin/tools/PluginStringManager.java
+++ b/src/main/java/fr/cnes/sonar/plugin/tools/PluginStringManager.java
@@ -30,6 +30,9 @@ import java.util.logging.Logger;
  */
 public class PluginStringManager {
     private static Properties properties = new Properties();
+    private PluginStringManager(){
+        throw new IllegalStateException("Utility class");
+    }
     protected static final Logger LOGGER = Logger.getLogger(PluginStringManager.class.getCanonicalName());
     static {
 

--- a/src/main/java/fr/cnes/sonar/plugin/tools/ZipFolder.java
+++ b/src/main/java/fr/cnes/sonar/plugin/tools/ZipFolder.java
@@ -17,8 +17,6 @@
 
 package fr.cnes.sonar.plugin.tools;
 
-import fr.cnes.sonar.report.factory.ReportFactory;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -58,9 +56,8 @@ public class ZipFolder {
                             LOGGER.warning(e.getMessage());
                         }
                     });
-            file.close();
         }
-        catch(IOException e){
+        finally {
             if(file!=null)
                 file.close();
         }

--- a/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
+++ b/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
@@ -35,6 +35,7 @@ import org.sonar.api.server.ws.Response;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 public class ExportTask implements RequestHandler {
 
@@ -67,7 +68,7 @@ public class ExportTask implements RequestHandler {
         final File outputDirectory = File.createTempFile("cnesreport", Long.toString(System.nanoTime()));
 
         // Last line create file instead of folder, we delete file to put folder at the same place later
-        outputDirectory.delete();
+        Files.delete(outputDirectory.toPath());
 
         // Start generation, re-using standalone script
         ReportCommandLine.execute(new String[]{
@@ -86,7 +87,7 @@ public class ExportTask implements RequestHandler {
 
 
         // Some cleaning
-        zip.delete();
+        Files.delete(zip.toPath());
         FileTools.deleteFolder(outputDirectory);
     }
 }

--- a/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
+++ b/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
@@ -75,7 +75,8 @@ public class ExportTask implements RequestHandler {
                 "-o", outputDirectory.getAbsolutePath(),
                 "-s", config.get("sonar.core.serverBaseURL").orElse(PluginStringManager.getProperty("plugin.defaultHost")),
                 "-p", request.getParam(PluginStringManager.getProperty("api.report.args.key")).getValue(),
-                "-a", request.getParam(PluginStringManager.getProperty("api.report.args.author")).getValue()
+                "-a", request.getParam(PluginStringManager.getProperty("api.report.args.author")).getValue(),
+                "-t", request.getParam(PluginStringManager.getProperty("api.report.args.token")).getValue()
         });
 
         // generate zip output and send it

--- a/src/main/java/fr/cnes/sonar/plugin/ws/ReportWs.java
+++ b/src/main/java/fr/cnes/sonar/plugin/ws/ReportWs.java
@@ -70,6 +70,11 @@ public class ReportWs implements WebService {
         authorParam.setDescription(PluginStringManager.getProperty("api.report.args.description.author"));
         authorParam.setRequired(true);
 
+        // Adding token argument
+        WebService.NewParam tokenParam = report.createParam(PluginStringManager.getProperty("api.report.args.token"));
+        tokenParam.setDescription(PluginStringManager.getProperty("api.report.args.description.token"));
+        tokenParam.setRequired(true);
+
     }
 }
 

--- a/src/main/java/fr/cnes/sonar/report/exporters/docx/DocXExporter.java
+++ b/src/main/java/fr/cnes/sonar/report/exporters/docx/DocXExporter.java
@@ -91,7 +91,7 @@ public class DocXExporter implements IExporter {
      * @throws XmlException ...
      */
     @Override
-    public File export(Object data, String path, String filename)
+    public File export(final Object data, final String path, final String filename)
             throws BadExportationDataTypeException, OpenXML4JException, IOException, XmlException {
         // check resources type
         if (!(data instanceof Report)) {
@@ -151,6 +151,5 @@ public class DocXExporter implements IExporter {
 
         return new File(path);
     }
-
 
 }

--- a/src/main/java/fr/cnes/sonar/report/exporters/docx/XWPFChartSpace.java
+++ b/src/main/java/fr/cnes/sonar/report/exporters/docx/XWPFChartSpace.java
@@ -17,23 +17,23 @@
 
 package fr.cnes.sonar.report.exporters.docx;
 
+import com.google.common.collect.Lists;
 import fr.cnes.sonar.report.model.Value;
 import org.apache.poi.POIXMLDocumentPart;
-import org.apache.poi.POIXMLTypeLoader;
 import org.apache.poi.openxml4j.opc.PackagePart;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.apache.xmlbeans.XmlException;
-import org.apache.xmlbeans.XmlObject;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTNumVal;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTPlotArea;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTStrVal;
+import org.openxmlformats.schemas.drawingml.x2006.chart.ChartSpaceDocument;
 import org.openxmlformats.schemas.drawingml.x2006.chart.impl.ChartSpaceDocumentImpl;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -45,7 +45,7 @@ public class XWPFChartSpace {
     /**
      * Encapsulated POI version of chart space
      */
-    private ChartSpaceDocumentImpl chartSpace;
+    private ChartSpaceDocument chartSpace;
 
     /**
      * {@link PackagePart} to save the current ChartSpaceDocument
@@ -59,7 +59,7 @@ public class XWPFChartSpace {
      * @param ctChartSpace a prebuilt chart space
      * @param chartPackagePart the package part corresponding to the chart
      */
-    public XWPFChartSpace(ChartSpaceDocumentImpl ctChartSpace, PackagePart chartPackagePart) {
+    public XWPFChartSpace(final ChartSpaceDocument ctChartSpace, final PackagePart chartPackagePart) {
         this.chartSpace = ctChartSpace;
         this.packagePart = chartPackagePart;
     }
@@ -72,33 +72,28 @@ public class XWPFChartSpace {
      * @throws IOException When reading files
      * @throws XmlException When reading files
      */
-    public static List<XWPFChartSpace> getChartSpaces(XWPFDocument document)
+    public static List<XWPFChartSpace> getChartSpaces(final XWPFDocument document)
             throws IOException, XmlException {
         // gather charts documents
-        final List<POIXMLDocumentPart> charts = new ArrayList<>();
+        final List<POIXMLDocumentPart> charts = Lists.newArrayList();
         // results list to return at the end
-        final List<XWPFChartSpace> result = new ArrayList<>();
+        final List<XWPFChartSpace> result = Lists.newArrayList();
 
         // get parts related to charts
-        for(POIXMLDocumentPart p : document.getRelations()) {
+        for(final POIXMLDocumentPart p : document.getRelations()) {
             if(p.toString().contains("/word/charts/")) {
                 charts.add(p);
             }
         }
 
         // get chart spaces inside previous parts
-        for(POIXMLDocumentPart p : charts) {
+        for(final POIXMLDocumentPart p : charts) {
             try {
                 final InputStream inputStream = p.getPackagePart().getInputStream();
-                final ChartSpaceDocumentImpl c = (ChartSpaceDocumentImpl)
-                        XmlObject.Factory.parse(inputStream,
-                                POIXMLTypeLoader.DEFAULT_XML_OPTIONS);
-
+                final ChartSpaceDocument c = ChartSpaceDocument.Factory.parse(inputStream);
                 result.add(new XWPFChartSpace(c, p.getPackagePart()));
-            }
-            catch (ClassCastException e){
-                e.printStackTrace();
-                LOGGER.warning("Error while getting charts, can't convert XMLObject into ChartSpaceDocumentImpl");
+            } catch(final ClassCastException e){
+                LOGGER.log(Level.WARNING, "Error while getting charts, can't convert XMLObject into ChartSpaceDocument", e);
             }
         }
 
@@ -109,7 +104,7 @@ public class XWPFChartSpace {
      * Getter for chartSpace
      * @return a CTChartSpace
      */
-    public ChartSpaceDocumentImpl getChartSpace() {
+    public ChartSpaceDocument getChartSpace() {
         return this.chartSpace;
     }
 
@@ -117,7 +112,7 @@ public class XWPFChartSpace {
      * Setter for chartSpace
      * @param ctChartSpace new chartSpace value
      */
-    public void setChartSpace(ChartSpaceDocumentImpl ctChartSpace) {
+    public void setChartSpace(final ChartSpaceDocumentImpl ctChartSpace) {
         this.chartSpace = ctChartSpace;
     }
 
@@ -133,9 +128,9 @@ public class XWPFChartSpace {
     /**
      * Set the value of chart's title
      * @param newTitle the new value
-     * @throws IOException error when writting the chart's file
+     * @throws IOException error when writing the chart's file
      */
-    public void setTitle(String newTitle) throws IOException {
+    public void setTitle(final String newTitle) throws IOException {
         chartSpace.getChartSpace().getChart().getTitle().getTx().getRich()
                 .getPList().get(0).getRList().get(0).setT(newTitle);
         this.save();
@@ -156,7 +151,7 @@ public class XWPFChartSpace {
      * @param values values to set as a list of label/value
      * @throws IOException when writing the file
      */
-    public void setValues(List<Value> values) throws IOException {
+    public void setValues(final List<Value> values) throws IOException {
         final CTPlotArea ctPlotArea = chartSpace.getChartSpace().getChart().getPlotArea();
 
         // if the chart is a pie chart we continue

--- a/src/main/java/fr/cnes/sonar/report/factory/ReportFactory.java
+++ b/src/main/java/fr/cnes/sonar/report/factory/ReportFactory.java
@@ -84,17 +84,6 @@ public class ReportFactory {
         final CSVExporter csvExporter = new CSVExporter();
         final MarkdownExporter markdownExporter =  new MarkdownExporter();
 
-        // Export in markdown if requested
-        if (configuration.isEnableMarkdown()) {
-            final String MDFilename = formatFilename(MD_FILENAME, configuration.getOutput(), model.getProjectName());
-            markdownExporter.export(model, MDFilename, model.getProjectName());
-        }
-        
-        // Export issues in report if requested
-        if(configuration.isEnableCSV()) {
-            final String CSVFilename = formatFilename(CSV_FILENAME, configuration.getOutput(), model.getProjectName());
-            csvExporter.export(model, CSVFilename, model.getProjectName());
-        }
 
         // Export analysis configuration if requested.
         if(configuration.isEnableConf()) {
@@ -115,6 +104,18 @@ public class ReportFactory {
             final String xlsXFilename = formatFilename(ISSUES_FILENAME, configuration.getOutput(), model.getProjectName());
             // export the xlsx issues' list
             issuesExporter.export(model, xlsXFilename, configuration.getTemplateSpreadsheet());
+        }
+
+        // Export in markdown if requested
+        if (configuration.isEnableMarkdown()) {
+            final String MDFilename = formatFilename(MD_FILENAME, configuration.getOutput(), model.getProjectName());
+            markdownExporter.export(model, MDFilename, model.getProjectName());
+        }
+
+        // Export issues in report if requested
+        if(configuration.isEnableCSV()) {
+            final String CSVFilename = formatFilename(CSV_FILENAME, configuration.getOutput(), model.getProjectName());
+            csvExporter.export(model, CSVFilename, model.getProjectName());
         }
     }
 

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -30,3 +30,5 @@ api.report.args.key=key
 api.report.args.description.key=Key of the project
 api.report.args.author=author
 api.report.args.description.author=Author of the report
+api.report.args.token=token
+api.report.args.description.token=Authentication token (for protected project)

--- a/src/main/resources/static/report.js
+++ b/src/main/resources/static/report.js
@@ -39,7 +39,19 @@ window.registerExtension('cnesreport/report', function (options) {
                 // we add it to the drop down list
                 $('#key').append(option);
             });
-        })
+        });
+
+        window.SonarRequest.post(
+                            '/api/user_tokens/revoke', {name: "cnes-report"}
+                ).then(function(){
+                    window.SonarRequest.postJSON(
+                        '/api/user_tokens/generate', {name: "cnes-report"}
+                    ).then(function (response) {
+                        $('#token_cnesreport').val(response.token)
+                    });
+
+                })
+                
     };
 
     // once the request is done, and the page is still displayed (not closed already)

--- a/src/main/resources/static/report.js
+++ b/src/main/resources/static/report.js
@@ -48,6 +48,13 @@ window.registerExtension('cnesreport/report', function (options) {
                         '/api/user_tokens/generate', {name: "cnes-report"}
                     ).then(function (response) {
                         $('#token_cnesreport').val(response.token)
+                        window.SonarRequest.getJSON(
+                            '/api/users/search',
+                            {"q":response.login}
+                        ).then(function (response) {
+                            // on success
+                            $('#author').val(response.users[0].name);
+                        });
                     });
 
                 })

--- a/src/main/resources/static/templates/reportForm.html
+++ b/src/main/resources/static/templates/reportForm.html
@@ -30,7 +30,7 @@
                     </em>
                 </div>
                 <div class="big-spacer-bottom">
-                    <label for="author" id="authorLabel" class="login-label" style="display: block;">Author</label>
+                    <label for="author" id="authorLabel" class="login-label" style="display: block;"><strong>Author</strong></label>
                     <input   type="text"
                              id="author"
                              name="author"
@@ -39,7 +39,6 @@
                              required
                              placeholder="Report's author">
                     <input type="hidden" name="token" id="token_cnesreport" value="noauth"/>
-                    <em style="color:grey;">Default value: default</em>
                 </div>
                 <div class="big-spacer-bottom">
                     <div id="loading" class="text-center overflow-hidden" style="margin-bottom: 1em; display: none;">

--- a/src/main/resources/static/templates/reportForm.html
+++ b/src/main/resources/static/templates/reportForm.html
@@ -38,6 +38,7 @@
                              maxlength="255"
                              required
                              placeholder="Report's author">
+                    <input type="hidden" name="token" id="token_cnesreport" value="noauth"/>
                     <em style="color:grey;">Default value: default</em>
                 </div>
                 <div class="big-spacer-bottom">

--- a/src/main/resources/template/code-analysis-template.md
+++ b/src/main/resources/template/code-analysis-template.md
@@ -2,7 +2,7 @@
 ## XX-PROJECTNAME-XX 
 #### Version XX-VERSION-XX 
 
-*By: XX-AUTHOR-XX*
+**By: XX-AUTHOR-XX**
 
 *Date: XX-DATE-XX*
 

--- a/src/test/it/run-test.sh
+++ b/src/test/it/run-test.sh
@@ -2,4 +2,4 @@
 
 cp src/main/resources/template/code-analysis-template.docx src/main/resources/template/issues-template.xlsx target
 cd target
-java -jar cnesreport.jar -p fr.cnes.sonar:cnesreport -s http://localhost:9000
+java -jar sonar-cnes-report.jar -p fr.cnes.sonar:cnesreport -s http://localhost:9000

--- a/src/test/it/run-test.sh
+++ b/src/test/it/run-test.sh
@@ -3,4 +3,3 @@
 cp src/main/resources/template/code-analysis-template.docx src/main/resources/template/issues-template.xlsx target
 cd target
 java -jar cnesreport.jar -p fr.cnes.sonar:cnesreport -s http://localhost:9000
-wget http://127.0.0.1:9000/api/cnesreport/report?key=fr.cnes.sonar%cnesreport&author=travis-ci


### PR DESCRIPTION
Update cnes-report to provide SonarQube 7.9LTS support.

# Fixed issues
* Fix #65 - cnes-report is now working with SonarQube 7 as plugin.
* Fix #68 - deprecated api calls are removed.
* Fix #72 - return a clean error when token is invalid
* Fix: error in metrics stats (docx report) when some file can't provide metrics.
* Fix: bad practice in file opening (raised by sonar), replace `open` with `try-with-ressources`.
* Fix: Blocker Issues (SonarCloud)
* Fix: Build fails on pull requests

# New
* Use the [SonarCloud app](https://github.com/marketplace/actions/sonarcloud-scan)