### PR TITLE
Use jdk8 with xenial to prevent build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
+dist: xenial
 language: java
-sudo: required
 install: true
 
 services:
@@ -10,8 +10,8 @@ addons:
     organization: "lequal"
 
 jdk:
-  - oraclejdk8
-  - oraclejdk11
+  - openjdk8
+  - openjdk11
 
 env:
   - sonarqube: none


### PR DESCRIPTION
Update travis to use openjdk and xenial dist

# Fixed issues
* Fix #101

# Proposed changes
* Use xenial and openjdk to prevent installation error when build start

NB: Build that check code quality will fail on PR because i'm not authorized to write on sonarcloud instance. Once merged, build should pass.
