### PR TITLE
Support for project branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
+dist: xenial
 language: java
-sudo: required
 install: true
 
 services:
@@ -10,8 +10,8 @@ addons:
     organization: "lequal"
 
 jdk:
-  - oraclejdk8
-  - oraclejdk11
+  - openjdk8
+  - openjdk11
 
 env:
   - sonarqube: none

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-dist: xenial
 language: java
+sudo: required
 install: true
 
 services:
@@ -10,8 +10,8 @@ addons:
     organization: "lequal"
 
 jdk:
-  - openjdk8
-  - openjdk11
+  - oraclejdk8
+  - oraclejdk11
 
 env:
   - sonarqube: none
@@ -49,8 +49,8 @@ script:
 
 cache:
   directories:
-  - '$HOME/.m2/repository'
-  - '$HOME/.sonar/cache'
+    - '$HOME/.m2/repository'
+    - '$HOME/.sonar/cache'
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ java -jar cnesreport.jar -t xuixg5hub345xbefu -s https://example.org:9000 -p pro
 ````
 
 ##### Export of a specific project branch (standalone)
-If you are using a commercial edition of sonarqube or the [sonarqube-community-branch-plugin](https://github.com/mc1arke/sonarqube-community-branch-plugin) you want to export the report for a specific branch of your project using the -b option. 
+If you are using a commercial edition of sonarqube or the [sonarqube-community-branch-plugin](https://github.com/mc1arke/sonarqube-community-branch-plugin) you can export the report for a specific branch of your project using the -b option. 
 ````
 java -jar cnesreport.jar -p projectId -b dev
 ````

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ usage: java -jar cnesreport.jar [-a <arg>] [-b <arg>] [-c] [-d <arg>] [-e] [-h] 
 Generate editable reports for SonarQube projects.
 
  -a,--author <arg>                 Name of the report writer.
- -b,--branch <arg>                 Branch of the targeted project. Requires Developer Edition or sonarqube-community-branch-plugin.
+ -b,--branch <arg>                 Branch of the targeted project. Requires Developer Edition or sonarqube-community-branch-plugin. Default: usage of main branch.
  -c,--disable-conf                 Disable export of quality configuration used during analysis.
  -d,--date <arg>                   Date for the report. Default: current date.
  -e,--disable-spreadsheet          Disable spreadsheet generation.

--- a/README.md
+++ b/README.md
@@ -32,11 +32,12 @@ This tool can be used in standalone as a JAR executable (with the command line) 
 #### Get help
 Use `java -jar cnesreport.jar -h` to get the following help about cnesreport:
 ````
-usage: java -jar cnesreport.jar [-a <arg>] [-c] [-d <arg>] [-e] [-h] [-l <arg>] [-o <arg>] [-p <arg>] [-r <arg>]
+usage: java -jar cnesreport.jar [-a <arg>] [-b <arg>] [-c] [-d <arg>] [-e] [-h] [-l <arg>] [-o <arg>] [-p <arg>] [-r <arg>]
        [-s <arg>] [-t <arg>] [-v] [-w] [-x <arg>]
 Generate editable reports for SonarQube projects.
 
  -a,--author <arg>                 Name of the report writer.
+ -b,--branch <arg>                 Branch of the targeted project. Requires Developer Edition or sonarqube-community-branch-plugin.
  -c,--disable-conf                 Disable export of quality configuration used during analysis.
  -d,--date <arg>                   Date for the report. Default: current date.
  -e,--disable-spreadsheet          Disable spreadsheet generation.
@@ -75,6 +76,12 @@ If you have installed cnes-report in your sonarqube: open web interface, click o
 If you are using a secured instance of SonarQube, you can provide a SonarQube authentication token thanks to `-t` option and specify the url of the SonarQube instance with `-s`. The internal template for the text report will be replace by the one given through `-r` option.
 ````
 java -jar cnesreport.jar -t xuixg5hub345xbefu -s https://example.org:9000 -p projectId -r ./template.docx
+````
+
+##### Export of a specific project branch (standalone)
+If you are using a commercial edition of sonarqube or the [sonarqube-community-branch-plugin](https://github.com/mc1arke/sonarqube-community-branch-plugin) you want to export the report for a specific branch of your project using the -b option. 
+````
+java -jar cnesreport.jar -p projectId -b dev
 ````
 
 ##### Enterprise features available for all

--- a/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
+++ b/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
@@ -26,6 +26,7 @@ import fr.cnes.sonar.report.exceptions.BadSonarQubeRequestException;
 import fr.cnes.sonar.report.exceptions.SonarQubeException;
 import fr.cnes.sonar.report.exceptions.UnknownQualityGateException;
 import fr.cnes.sonar.report.factory.ReportFactory;
+import fr.cnes.sonar.report.utils.StringManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
 import org.apache.xmlbeans.XmlException;
@@ -38,6 +39,9 @@ import org.sonar.api.utils.text.JsonWriter;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class ExportTask implements RequestHandler {
 
@@ -75,15 +79,17 @@ public class ExportTask implements RequestHandler {
 
         // Start generation, re-using standalone script
         try {
+            final Request.StringParam pBranch =
+                    request.getParam(PluginStringManager.getProperty("api.report.args.branch"));
             ReportCommandLine.execute(new String[]{
                     "report",
                     "-o", outputDirectory.getAbsolutePath(),
                     "-s", config.get("sonar.core.serverBaseURL").orElse(PluginStringManager.getProperty("plugin.defaultHost")),
                     "-p", projectKey,
+                    "-b", pBranch.isPresent()?pBranch.getValue(): StringManager.NO_BRANCH,
                     "-a", request.getParam(PluginStringManager.getProperty("api.report.args.author")).getValue(),
                     "-t", request.getParam(PluginStringManager.getProperty("api.report.args.token")).getValue()
             });
-
 
             stream.setMediaType("application/zip");
             String filename = ReportFactory.formatFilename("zip.report.output", "", projectKey);

--- a/src/main/java/fr/cnes/sonar/plugin/ws/ReportWs.java
+++ b/src/main/java/fr/cnes/sonar/plugin/ws/ReportWs.java
@@ -75,6 +75,10 @@ public class ReportWs implements WebService {
         tokenParam.setDescription(PluginStringManager.getProperty("api.report.args.description.token"));
         tokenParam.setRequired(true);
 
+        // Adding branch argument
+        WebService.NewParam branchParam = report.createParam(PluginStringManager.getProperty("api.report.args.branch"));
+        branchParam.setDescription(PluginStringManager.getProperty("api.report.args.description.branch"));
+        branchParam.setRequired(false);
     }
 }
 

--- a/src/main/java/fr/cnes/sonar/report/factory/ProviderFactory.java
+++ b/src/main/java/fr/cnes/sonar/report/factory/ProviderFactory.java
@@ -41,19 +41,26 @@ public class ProviderFactory {
     /** Key of the project to report. */
     private String projectKey;
 
+    /** Branch of the project to report. */
+    private String branch;
+
     /**
      * Constructor.
      * @param server Represents the server.
      * @param token String representing the user token.
      * @param project The id of the project to report.
+     * @param branch The branch of the project to report.
      */
-    public ProviderFactory(final SonarQubeServer server, final String token, final String project) {
+    public ProviderFactory(final SonarQubeServer server, final String token, final String project,
+            final String branch) {
         // get sonar server
         this.server = server;
         // get user token
         this.token = token;
         // get project key
         this.projectKey = project;
+        // get branch
+        this.branch = branch;
     }
 
     /**
@@ -77,6 +84,8 @@ public class ProviderFactory {
                     provider = constructors[0].newInstance(server, token);
                 } else if (3 == constructors[0].getParameterCount()) {
                     provider = constructors[0].newInstance(server, token, projectKey);
+                } else if (4 == constructors[0].getParameterCount()) {
+                    provider = constructors[0].newInstance(server, token, projectKey, branch);
                 }
             }
         } catch (IllegalAccessException | InvocationTargetException | InstantiationException e) {

--- a/src/main/java/fr/cnes/sonar/report/factory/ReportModelFactory.java
+++ b/src/main/java/fr/cnes/sonar/report/factory/ReportModelFactory.java
@@ -43,6 +43,10 @@ public class ReportModelFactory {
      */
     private String project;
     /**
+     * Branch of the project to report.
+     */
+    private String branch;
+    /**
      * Author of the project to report.
      */
     private String author;
@@ -60,6 +64,7 @@ public class ReportModelFactory {
         this.server = pServer;
         this.token = pConfiguration.getToken();
         this.project = pConfiguration.getProject();
+        this.branch = pConfiguration.getBranch();
         this.author = pConfiguration.getAuthor();
         this.date = pConfiguration.getDate();
     }
@@ -76,7 +81,8 @@ public class ReportModelFactory {
         final Report report = new Report();
 
         // instantiation of providers
-        final ProviderFactory providerFactory = new ProviderFactory(this.server, this.token, this.project);
+        final ProviderFactory providerFactory = new ProviderFactory(this.server, this.token, this.project,
+                this.branch);
         final IssuesProvider issuesProvider = providerFactory.create(IssuesProvider.class);
         final MeasureProvider measureProvider = providerFactory.create(MeasureProvider.class);
         final ProjectProvider projectProvider = providerFactory.create(ProjectProvider.class);
@@ -90,7 +96,7 @@ public class ReportModelFactory {
         // date setting
         report.setProjectDate(this.date);
 
-        if(!projectProvider.hasProject(this.project)) {
+        if(!projectProvider.hasProject(this.project, this.branch)) {
             throw new SonarQubeException(String.format("Unknown project '%s' on SonarQube instance.", this.project));
         }
 
@@ -100,7 +106,7 @@ public class ReportModelFactory {
         report.setComponents(componentProvider.getComponents());
         report.setMetricsStats(componentProvider.getMetricStats());
         // set report basic data
-        report.setProject(projectProvider.getProject(projectProvider.getProjectKey()));
+        report.setProject(projectProvider.getProject(projectProvider.getProjectKey(), projectProvider.getBranch()));
         // project's name's setting
         report.setProjectName(report.getProject().getName());
         // formatted issues, unconfirmed issues and raw issues' setting

--- a/src/main/java/fr/cnes/sonar/report/model/Project.java
+++ b/src/main/java/fr/cnes/sonar/report/model/Project.java
@@ -35,6 +35,10 @@ public class Project {
      */
     private String name;
     /**
+     * Branch of the project
+     */
+    private String branch;
+    /**
      * Name of the organization
      */
     private String organization;
@@ -64,7 +68,7 @@ public class Project {
      * @param pDescription Project's description
      */
     public Project(final String pKey, final String pName, final String pOrganization,
-                   final String pVersion, final String pDescription) {
+                   final String pVersion, final String pDescription, final String pBranch) {
         this.key = pKey;
         this.name = pName;
         this.organization = pOrganization;
@@ -72,6 +76,7 @@ public class Project {
         this.description = pDescription;
         this.qualityProfiles = new ProfileMetaData[0];
         this.languages = new HashMap<>();
+        this.branch=pBranch;
     }
 
     /**
@@ -104,6 +109,22 @@ public class Project {
      */
     public void setName(final String pName) {
         this.name = pName;
+    }
+
+    /**
+     * Getter for branch
+     * @return branch
+     */
+    public String getBranch() {
+        return branch;
+    }
+
+    /**
+     * Setter for branch
+     * @param pBranch value
+     */
+    public void setBranch(final String pBranch) {
+        this.branch = pBranch;
     }
 
     /**

--- a/src/main/java/fr/cnes/sonar/report/model/Report.java
+++ b/src/main/java/fr/cnes/sonar/report/model/Report.java
@@ -94,7 +94,7 @@ public class Report {
         this.rawIssues = new ArrayList<>();
         this.components = new ArrayList<>();
         this.project = new Project(StringManager.EMPTY, StringManager.EMPTY,
-                StringManager.EMPTY,StringManager.EMPTY,StringManager.EMPTY);
+                StringManager.EMPTY,StringManager.EMPTY,StringManager.EMPTY, StringManager.EMPTY);
     }
 
     /**

--- a/src/main/java/fr/cnes/sonar/report/providers/AbstractDataProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/AbstractDataProvider.java
@@ -194,6 +194,11 @@ public abstract class AbstractDataProvider {
     protected String projectKey;
 
     /**
+     * The branch of the project
+     */
+    protected String branch;
+
+    /**
      * Name of the used quality gate
      */
     protected String qualityGateName;
@@ -217,7 +222,27 @@ public abstract class AbstractDataProvider {
 
     /**
      * Constructor.
-     *  @param server SonarQube server.
+     * @param server SonarQube server.
+     * @param token String representing the user token.
+     * @param project The id of the project to report.
+     * @param branch The branch of the project to report.
+     */
+    AbstractDataProvider(final SonarQubeServer server, final String token, final String project, final String branch) {
+        // json tool
+        this.gson = new Gson();
+        // get sonar server
+        this.server = server;
+        // get user token
+        this.token = token;
+        // get project key
+        this.projectKey = project;
+        // get branch
+        this.branch = branch;
+    }
+
+    /**
+     * Constructor.
+     * @param server SonarQube server.
      * @param token String representing the user token.
      * @param project The id of the project to report.
      */
@@ -383,6 +408,22 @@ public abstract class AbstractDataProvider {
      */
     public void setProjectKey(final String pProjectKey) {
         this.projectKey = pProjectKey;
+    }
+
+    /**
+     * Branch of the project to report or "%" if branch was not set (default)
+     * @return the project branch as a String
+     */
+    public String getBranch() {
+        return branch;
+    }
+
+    /**
+     * Setter of branch
+     * @param branch value to give
+     */
+    public void setBranch(final String branch) {
+        this.branch = branch;
     }
 
     /**

--- a/src/main/java/fr/cnes/sonar/report/providers/ComponentProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/ComponentProvider.java
@@ -37,11 +37,12 @@ public class ComponentProvider extends AbstractDataProvider {
      * @param server  SonarQube server.
      * @param token   String representing the user token.
      * @param project The id of the component to report.
+     * @param project The branch of the component to report.
      */
-
     ArrayList<Map> componentsList;
-    public ComponentProvider(final SonarQubeServer server, final String token, final String project) {
-        super(server, token, project);
+    public ComponentProvider(final SonarQubeServer server, final String token, final String project,
+            final String branch) {
+        super(server, token, project, branch);
         componentsList =  new ArrayList<>();
     }
 
@@ -58,7 +59,7 @@ public class ComponentProvider extends AbstractDataProvider {
         while(goOn){
             // Send request to server
             jo = request(String.format(getRequest(GET_COMPONENTS_REQUEST),
-                    getServer().getUrl(), getProjectKey(), page, getRequest(MAX_PER_PAGE_SONARQUBE)));
+                    getServer().getUrl(), getProjectKey(), page, getRequest(MAX_PER_PAGE_SONARQUBE), getBranch()));
 
             // Get components from response
             final Component[] tmp = getGson().fromJson(jo.get(COMPONENTS), Component[].class);

--- a/src/main/java/fr/cnes/sonar/report/providers/IssuesProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/IssuesProvider.java
@@ -55,9 +55,11 @@ public class IssuesProvider extends AbstractDataProvider {
      * @param pServer SonarQube server.
      * @param pToken String representing the user token.
      * @param pProject The id of the project to report.
+     * @param pBranch The branch of the project to report.
      */
-    public IssuesProvider(final SonarQubeServer pServer, final String pToken, final String pProject) {
-        super(pServer, pToken, pProject);
+    public IssuesProvider(final SonarQubeServer pServer, final String pToken, final String pProject,
+            final String pBranch) {
+        super(pServer, pToken, pProject, pBranch);
     }
 
     /**
@@ -111,7 +113,7 @@ public class IssuesProvider extends AbstractDataProvider {
             final int maxPerPage = Integer.parseInt(getRequest(MAX_PER_PAGE_SONARQUBE));
             // prepare the server to get all the issues
             final String request = String.format(getRequest(GET_ISSUES_REQUEST),
-                    getServer().getUrl(), getProjectKey(), maxPerPage, page, confirmed);
+                    getServer().getUrl(), getProjectKey(), maxPerPage, page, confirmed, getBranch());
             // perform the request to the server
             final JsonObject jo = request(request);
             // transform json to Issue and Rule objects
@@ -213,7 +215,7 @@ public class IssuesProvider extends AbstractDataProvider {
             final int maxPerPage = Integer.parseInt(getRequest(MAX_PER_PAGE_SONARQUBE));
             // prepare the server to get all the issues
             final String request = String.format(getRequest(GET_ISSUES_REQUEST),
-                    getServer().getUrl(), getProjectKey(), maxPerPage, page, CONFIRMED);
+                    getServer().getUrl(), getProjectKey(), maxPerPage, page, CONFIRMED, getBranch());
             // perform the request to the server
             final JsonObject jo = request(request);
             // transform json to Issue objects
@@ -252,7 +254,7 @@ public class IssuesProvider extends AbstractDataProvider {
 
         // prepare the request
         final String request = String.format(getRequest(GET_FACETS_REQUEST),
-                getServer().getUrl(), getProjectKey());
+                getServer().getUrl(), getProjectKey(), getBranch());
         // contact the server to request the resources as json
         final JsonObject jo = request(request);
         // put wanted resources in facets array and list

--- a/src/main/java/fr/cnes/sonar/report/providers/MeasureProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/MeasureProvider.java
@@ -38,9 +38,11 @@ public class MeasureProvider extends AbstractDataProvider {
      * @param pServer SonarQube server..
      * @param pToken String representing the user token.
      * @param pProject The id of the project to report.
+     * @param pBranch The branch of the project to report.
      */
-    public MeasureProvider(final SonarQubeServer pServer, final String pToken, final String pProject) {
-        super(pServer, pToken, pProject);
+    public MeasureProvider(final SonarQubeServer pServer, final String pToken, final String pProject,
+            final String pBranch) {
+        super(pServer, pToken, pProject, pBranch);
     }
 
     /**
@@ -53,7 +55,7 @@ public class MeasureProvider extends AbstractDataProvider {
         // send a request to sonarqube server and return th response as a json object
         // if there is an error on server side this method throws an exception
         final JsonObject jo = request(String.format(getRequest(GET_MEASURES_REQUEST),
-                getServer().getUrl(), getProjectKey()));
+                getServer().getUrl(), getProjectKey(), getBranch()));
 
         // json element containing measure information
         final JsonElement measuresJE = jo.get(COMPONENT).getAsJsonObject().get(MEASURES);

--- a/src/main/java/fr/cnes/sonar/report/providers/ProjectProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/ProjectProvider.java
@@ -40,24 +40,27 @@ public class ProjectProvider extends AbstractDataProvider {
      * @param pServer SonarQube server..
      * @param pToken String representing the user token.
      * @param pProject The id of the project to report.
+     * @param pBranch The branch of the project to report.
      */
-    public ProjectProvider(final SonarQubeServer pServer, final String pToken, final String pProject) {
-        super(pServer, pToken, pProject);
+    public ProjectProvider(final SonarQubeServer pServer, final String pToken, final String pProject,
+            final String pBranch) {
+        super(pServer, pToken, pProject, pBranch);
         languageProvider = new LanguageProvider(pServer, pToken, pProject);
     }
 
     /**
      * Get the project corresponding to the given key.
      * @param projectKey the key of the project.
+     * @param branch the branch of the project.
      * @return A simple project.
      * @throws BadSonarQubeRequestException when the server does not understand the request.
      * @throws SonarQubeException When SonarQube server is not callable.
      */
-    public Project getProject(final String projectKey) throws BadSonarQubeRequestException, SonarQubeException {
+    public Project getProject(final String projectKey, final String branch) throws BadSonarQubeRequestException, SonarQubeException {
         // send a request to sonarqube server and return th response as a json object
         // if there is an error on server side this method throws an exception
         JsonObject jo = request(String.format(getRequest(GET_PROJECT_REQUEST),
-                getServer().getUrl(), projectKey));
+                getServer().getUrl(), projectKey, branch));
 
         // put json in a Project class
         final Project project = (getGson().fromJson(jo, Project.class));
@@ -97,15 +100,16 @@ public class ProjectProvider extends AbstractDataProvider {
     /**
      * Check if a project exists on a SonarQube instance.
      * @param projectKey the key of the project.
+     * @param branch the branch of the project.
      * @return True if the project exists.
      * @throws BadSonarQubeRequestException when the server does not understand the request.
      * @throws SonarQubeException When SonarQube server is not callable.
      */
-    public boolean hasProject(final String projectKey) throws BadSonarQubeRequestException, SonarQubeException {
+    public boolean hasProject(final String projectKey, final String branch) throws BadSonarQubeRequestException, SonarQubeException {
         // send a request to sonarqube server and return th response as a json object
         // if there is an error on server side this method throws an exception
         final JsonObject jsonObject = request(String.format(getRequest(GET_PROJECT_REQUEST),
-                getServer().getUrl(), projectKey));
+                getServer().getUrl(), projectKey, branch));
 
         // Retrieve project key if the project exists or null.
         final String project = jsonObject.get("key").getAsString();

--- a/src/main/java/fr/cnes/sonar/report/providers/QualityGateProvider.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/QualityGateProvider.java
@@ -48,9 +48,11 @@ public class QualityGateProvider extends AbstractDataProvider {
      * @param pServer SonarQube server.
      * @param pToken String representing the user token.
      * @param pProject The id of the project to report.
+     * @param pBranch The branch of the project to report.
      */
-    public QualityGateProvider(final SonarQubeServer pServer, final String pToken, final String pProject) {
-        super(pServer, pToken, pProject);
+    public QualityGateProvider(final SonarQubeServer pServer, final String pToken, final String pProject,
+            final String pBranch) {
+        super(pServer, pToken, pProject, pBranch);
     }
 
     /**
@@ -109,7 +111,7 @@ public class QualityGateProvider extends AbstractDataProvider {
         final List<QualityGate> qualityGates = getQualityGates();
         // request the criteria
         String request = String.format(getRequest(GET_QUALITY_GATE_REQUEST),
-                getServer().getUrl(), getProjectKey());
+                getServer().getUrl(), getProjectKey(), getBranch());
         // Final quality gate result.
         QualityGate res;
 

--- a/src/main/java/fr/cnes/sonar/report/providers/RequestManager.java
+++ b/src/main/java/fr/cnes/sonar/report/providers/RequestManager.java
@@ -134,7 +134,7 @@ public final class RequestManager {
             case 403:
                 throw new BadSonarQubeRequestException("Insufficient privileges error sent by SonarQube server (code 403), please check your permissions in SonarQube configuration.");
             case 404:
-                throw new BadSonarQubeRequestException("Unknown URL error sent by SonarQube server (code 404), please check cnesreport compatibility with your SonarQube server version.");
+                throw new BadSonarQubeRequestException(String.format("Not found error sent by SonarQube server (code 404, URL %s, Error %s), please check cnesreport compatibility with your SonarQube server version.",response.requestUrl(), response.content()));
         }
 
         return response.content();

--- a/src/main/java/fr/cnes/sonar/report/utils/CommandLineManager.java
+++ b/src/main/java/fr/cnes/sonar/report/utils/CommandLineManager.java
@@ -47,7 +47,7 @@ public class CommandLineManager {
             {"s", "server", Boolean.TRUE.toString(), "Complete URL of the targeted SonarQube server."},
             {"t", "token", Boolean.TRUE.toString(), "SonarQube token of the SonarQube user who has permissions on the project."},
             {"p", "project", Boolean.TRUE.toString(), "SonarQube key of the targeted project."},
-            {"b", "branch", Boolean.TRUE.toString(), "Branch of the targeted project. Works only with Developer Edition or branch-plugin."},
+            {"b", "branch", Boolean.TRUE.toString(), "Branch of the targeted project. Requires Developer Edition or sonarqube-community-branch-plugin."},
             {"o", "output", Boolean.TRUE.toString(), "Output path for exported resources."},
             {"l", "language", Boolean.TRUE.toString(), "Language of the report. Values: en_US, fr_FR. Default: en_US."},
             {"a", "author", Boolean.TRUE.toString(), "Name of the report writer."},

--- a/src/main/java/fr/cnes/sonar/report/utils/CommandLineManager.java
+++ b/src/main/java/fr/cnes/sonar/report/utils/CommandLineManager.java
@@ -47,6 +47,7 @@ public class CommandLineManager {
             {"s", "server", Boolean.TRUE.toString(), "Complete URL of the targeted SonarQube server."},
             {"t", "token", Boolean.TRUE.toString(), "SonarQube token of the SonarQube user who has permissions on the project."},
             {"p", "project", Boolean.TRUE.toString(), "SonarQube key of the targeted project."},
+            {"b", "branch", Boolean.TRUE.toString(), "Branch of the targeted project. Works only with Developer Edition or branch-plugin."},
             {"o", "output", Boolean.TRUE.toString(), "Output path for exported resources."},
             {"l", "language", Boolean.TRUE.toString(), "Language of the report. Values: en_US, fr_FR. Default: en_US."},
             {"a", "author", Boolean.TRUE.toString(), "Name of the report writer."},

--- a/src/main/java/fr/cnes/sonar/report/utils/CommandLineManager.java
+++ b/src/main/java/fr/cnes/sonar/report/utils/CommandLineManager.java
@@ -47,7 +47,7 @@ public class CommandLineManager {
             {"s", "server", Boolean.TRUE.toString(), "Complete URL of the targeted SonarQube server."},
             {"t", "token", Boolean.TRUE.toString(), "SonarQube token of the SonarQube user who has permissions on the project."},
             {"p", "project", Boolean.TRUE.toString(), "SonarQube key of the targeted project."},
-            {"b", "branch", Boolean.TRUE.toString(), "Branch of the targeted project. Requires Developer Edition or sonarqube-community-branch-plugin."},
+            {"b", "branch", Boolean.TRUE.toString(), "Branch of the targeted project. Requires Developer Edition or sonarqube-community-branch-plugin. Default: usage of main branch."},
             {"o", "output", Boolean.TRUE.toString(), "Output path for exported resources."},
             {"l", "language", Boolean.TRUE.toString(), "Language of the report. Values: en_US, fr_FR. Default: en_US."},
             {"a", "author", Boolean.TRUE.toString(), "Name of the report writer."},

--- a/src/main/java/fr/cnes/sonar/report/utils/ReportConfiguration.java
+++ b/src/main/java/fr/cnes/sonar/report/utils/ReportConfiguration.java
@@ -35,6 +35,8 @@ public class ReportConfiguration {
     private String token;
     /** Options for p. */
     private String project;
+    /** Options for b. */
+    private String branch;
     /** Options for o. */
     private String output;
     /** Options for l. */
@@ -76,6 +78,7 @@ public class ReportConfiguration {
      * @param enableSpreadsheet Value for e option.
      * @param templateReport Value for r option.
      * @param templateSpreadsheet Value for x option.
+     * @param branch Value for b option.
      */
     private ReportConfiguration(final boolean help, final boolean version, final String server,
                                 final String token, final String project, final String output,
@@ -83,7 +86,7 @@ public class ReportConfiguration {
                                 final boolean enableConf, final boolean enableReport,
                                 final boolean enableSpreadsheet, final boolean enableCSV,
                                 final boolean enableMarkdown, String templateReport,
-                                final String templateSpreadsheet, final String templateMarkdown) {
+                                final String templateSpreadsheet, final String templateMarkdown, final String branch) {
         this.help = help;
         this.version = version;
         this.server = server;
@@ -101,6 +104,7 @@ public class ReportConfiguration {
         this.templateReport = templateReport;
         this.templateSpreadsheet = templateSpreadsheet;
         this.templateMarkdown = templateMarkdown;
+        this.branch = branch;
     }
 
     /**
@@ -116,6 +120,7 @@ public class ReportConfiguration {
         commandLineManager.parse(pArgs);
 
         // Final result to return.
+        final String branch = commandLineManager.getOptionValue("b", StringManager.NO_BRANCH);
         return new ReportConfiguration(
                 commandLineManager.hasOption("h"),
                 commandLineManager.hasOption("v"),
@@ -133,7 +138,9 @@ public class ReportConfiguration {
                 !commandLineManager.hasOption("m"),
                 commandLineManager.getOptionValue("r", StringManager.EMPTY),
                 commandLineManager.getOptionValue("x", StringManager.EMPTY),
-                commandLineManager.getOptionValue("n", StringManager.EMPTY));
+                commandLineManager.getOptionValue("n", StringManager.EMPTY),
+                branch.isEmpty()?StringManager.NO_BRANCH:branch
+        );
     }
 
     public boolean isHelp() {
@@ -154,6 +161,10 @@ public class ReportConfiguration {
 
     public String getProject() {
         return project;
+    }
+
+    public String getBranch() {
+        return branch;
     }
 
     public String getOutput() {

--- a/src/main/java/fr/cnes/sonar/report/utils/StringManager.java
+++ b/src/main/java/fr/cnes/sonar/report/utils/StringManager.java
@@ -38,6 +38,8 @@ public final class StringManager {
     public static final String TAB = "\t";
     /** Just a space. */
     public static final String SPACE = " ";
+    /** Placeholder for no-branch. */
+    public static final String NO_BRANCH = "%";
     /** Just a space for URI. */
     public static final String URI_SPACE = "%20";
     /** Name for properties' file about report. */

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -28,6 +28,8 @@ api.report.actionKey=report
 
 api.report.args.key=key
 api.report.args.description.key=Key of the project
+api.report.args.branch=branch
+api.report.args.description.branch=Branch of the project
 api.report.args.author=author
 api.report.args.description.author=Author of the report
 api.report.args.token=token

--- a/src/main/resources/requests.properties
+++ b/src/main/resources/requests.properties
@@ -18,13 +18,13 @@
 #Number max of results per page
 MAX_PER_PAGE_SONARQUBE = 500
 # Request to get the list of components and their metrics
-GET_COMPONENTS_REQUEST = %s/api/measures/component_tree?component=%s&metricKeys=ncloc,comment_lines_density,coverage,complexity,cognitive_complexity,duplicated_lines_density&p=%s&ps=%s
+GET_COMPONENTS_REQUEST = %s/api/measures/component_tree?component=%s&metricKeys=ncloc,comment_lines_density,coverage,complexity,cognitive_complexity,duplicated_lines_density&p=%s&ps=%s&branch=%s
 # Request to get the list of metrics
-GET_MEASURES_REQUEST = %s/api/measures/component?component=%s&metricKeys=ncloc,violations,ncloc_language_distribution,duplicated_lines_density,coverage,sqale_rating,reliability_rating,security_rating,alert_status,complexity,function_complexity,file_complexity,class_complexity,blocker_violations,critical_violations,major_violations,minor_violations,info_violations,new_violations,bugs,vulnerabilities,code_smells
+GET_MEASURES_REQUEST = %s/api/measures/component?component=%s&metricKeys=ncloc,violations,ncloc_language_distribution,duplicated_lines_density,coverage,sqale_rating,reliability_rating,security_rating,alert_status,complexity,function_complexity,file_complexity,class_complexity,blocker_violations,critical_violations,major_violations,minor_violations,info_violations,new_violations,bugs,vulnerabilities,code_smells&branch=%s
 # Request for getting a specific project
-GET_PROJECT_REQUEST = %s/api/navigation/component?component=%s
+GET_PROJECT_REQUEST = %s/api/navigation/component?component=%s&branch=%s
 # Request information about a project where quality gate is available
-GET_QUALITY_GATE_REQUEST=%s/api/navigation/component?component=%s
+GET_QUALITY_GATE_REQUEST=%s/api/navigation/component?component=%s&branch=%s
 # Request to get the list of quality gates
 GET_QUALITY_GATES_REQUEST = %s/api/qualitygates/list
 # Request to get the details of a quality gate
@@ -44,8 +44,8 @@ GET_QUALITY_PROFILES_PROJECTS_REQUEST = %s/api/qualityprofiles/projects?key=%s
 # Request to get the list of projects linked to a profile in SQ 5.X
 GET_PROJECT_QUALITY_PROFILES_REQUEST = %s/api/qualityprofiles/search?projectKey=%s
 # Request to get the list of issues linked to a project
-GET_ISSUES_REQUEST = %s/api/issues/search?projects=%s&facets=types,rules,severities,directories,fileUuids,tags&ps=%d&p=%d&additionalFields=rules,comments&resolved=%s
+GET_ISSUES_REQUEST = %s/api/issues/search?projects=%s&facets=types,rules,severities,directories,fileUuids,tags&ps=%d&p=%d&additionalFields=rules,comments&resolved=%s&branch=%s
 # Request to get the list of a project's facets
-GET_FACETS_REQUEST = %s/api/issues/search?projects=%s&resolved=false&facets=rules,severities,types&ps=1&p=1
+GET_FACETS_REQUEST = %s/api/issues/search?projects=%s&resolved=false&facets=rules,severities,types&ps=1&p=1&branch=%s
 # Request to get the list of a project's facets
 GET_LANGUAGES = %s/api/languages/list

--- a/src/test/ut/java/fr/cnes/sonar/report/CommonTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/CommonTest.java
@@ -158,7 +158,7 @@ public abstract class CommonTest {
         profileMetaData.setName("BG");
         profileMetaData.setKey("BG");
         final QualityProfile qualityProfile = new QualityProfile(profileData, profileMetaData);
-        qualityProfile.setProjects((new Project[]{new Project("sonar-cnes-plugin", "sonar-cnes-plugin", "none","","")}));
+        qualityProfile.setProjects((new Project[]{new Project("sonar-cnes-plugin", "sonar-cnes-plugin", "none", "", "", "")}));
         report.setQualityProfiles(Collections.singletonList(qualityProfile));
         final QualityGate qualityGate = new QualityGate();
         qualityGate.setName("CNES");
@@ -171,7 +171,7 @@ public abstract class CommonTest {
         final Map<String, Language> languages = new HashMap<>();
         languages.put(language.getKey(), language);
 
-        final Project project = new Project("key", "Name", "none","Version", "Short description");
+        final Project project = new Project("key", "Name", "none","Version", "Short description", "");
         project.setQualityProfiles(new ProfileMetaData[0]);
         project.setLanguages(languages);
         report.setProject(project);

--- a/src/test/ut/java/fr/cnes/sonar/report/factory/ProviderFactoryTest.java
+++ b/src/test/ut/java/fr/cnes/sonar/report/factory/ProviderFactoryTest.java
@@ -16,10 +16,11 @@ public class ProviderFactoryTest extends CommonTest {
 
     private static final String TOKEN = "token";
     private static final String PROJECT = "project";
+    private static final String BRANCH = "branch";
 
     @Test
     public void createTest() {
-        final ProviderFactory providerFactory = new ProviderFactory(sonarQubeServer, TOKEN, PROJECT);
+        final ProviderFactory providerFactory = new ProviderFactory(sonarQubeServer, TOKEN, PROJECT, BRANCH);
         Assert.assertNotNull(providerFactory);
 
         AbstractDataProvider provider = providerFactory.create(IssuesProvider.class);


### PR DESCRIPTION
# Proposed changes
* Implementation for feature request #96 

This pull request adds support for the **branches feature** in the commercial sonarqube editions and the [sonarqube-community-branch-plugin](https://github.com/mc1arke/sonarqube-community-branch-plugin).
It adds the (optional) new command line parameter **-b** which can be used to select a specific branch (see README.md).
If the parameter is not set, the default branch is exported (like before).

**Note**: The plugin web-form is not extended with this pull request. The new feature can only be used from the command line or rest-service.

**Travis**: I had to adjust the `.travis.yml` to make the build work with java8.