### PR TITLE
Change SonarQube local URL build process

### DIFF
--- a/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
+++ b/src/main/java/fr/cnes/sonar/plugin/ws/ExportTask.java
@@ -78,10 +78,15 @@ public class ExportTask implements RequestHandler {
         try {
             final Request.StringParam pBranch =
                     request.getParam(PluginStringManager.getProperty("api.report.args.branch"));
+
+            // Build SonarQube local URL
+            String port = config.get("sonar.web.port").orElse(PluginStringManager.getProperty("plugin.defaultPort"));
+            String host = String.format(PluginStringManager.getProperty("plugin.defaultHost"), port);
+
             ReportCommandLine.execute(new String[]{
                     "report",
                     "-o", outputDirectory.getAbsolutePath(),
-                    "-s", config.get("sonar.core.serverBaseURL").orElse(PluginStringManager.getProperty("plugin.defaultHost")),
+                    "-s", host,
                     "-p", projectKey,
                     "-b", pBranch.isPresent()?pBranch.getValue(): StringManager.NO_BRANCH,
                     "-a", request.getParam(PluginStringManager.getProperty("api.report.args.author")).getValue(),

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -19,7 +19,8 @@ homepage.url=cnesreport/report
 homepage.name=CNES Report
 
 plugin.since=6.5
-plugin.defaultHost=http://localhost:9000
+plugin.defaultHost=http://localhost:%s
+plugin.defaultPort=9000
 
 api.url=api/cnesreport
 api.description=Export a report in zip file.


### PR DESCRIPTION
Change how the plugin builds the local SonarQube URL to then make API calls.
Taking into account the fact that SonarQube may not be using the default port 9000.
The previous property to get the FQDN was not working (empty variable), so switching to the default value (localhost).

# Fixed issues
* Fix #148 